### PR TITLE
refactor(tests): noir_XPath test scaffolding cleanup phases 1+2 (mirror noir_IEEE754 #38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 scripts/qt3tests/
 __pycache__/
 *.pyc
+
+# nargo creates Prover.toml on the unit-test crate when it runs
+xpath_unit_tests/Prover.toml

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -28,16 +28,35 @@ from typing import Optional
 from elementpath import XPath2Parser
 from elementpath.datatypes import DateTime10, Date10, Time, DayTimeDuration
 
-# qt3tests catalogue parser (extracted from this script -- see
-# `scripts/noir_xpath_inputs/qt3tests.py`).
-from noir_xpath_inputs.qt3tests import (
+# qt3tests catalogue parser + XPath/XSD constants (extracted from this
+# script -- see `scripts/noir_xpath_inputs/`).
+from noir_xpath_inputs import (
     QT3_NS,
     TestCase,
+    XSD_INTEGER_I32_MAX,
+    XSD_INTEGER_I32_MIN,
+    XSD_INTEGER_I64_MAX,
+    XSD_INTEGER_I64_MIN,
+    XSD_MICROS_PER_DAY,
+    XSD_MICROS_PER_HOUR,
+    XSD_MICROS_PER_MINUTE,
+    XSD_MICROS_PER_SECOND,
+    XSD_MONTHS_PER_YEAR,
     clone_or_update_qt3tests,
     discover_all_test_files,
     discover_available_functions,
+    fits_in_i32 as _fits_in_i32,
+    fits_in_i64 as _fits_in_i64,
     parse_test_file,
+    time_components_to_micros,
+    tz_offset_to_micros,
+    years_months_to_total_months,
 )
+
+# i64 / i32 bounds (kept as module-level aliases for the call sites that
+# reference them by name; sourced from `noir_xpath_inputs.constants`).
+I64_MIN = XSD_INTEGER_I64_MIN
+I64_MAX = XSD_INTEGER_I64_MAX
 
 
 # Cached set of crate-root exports from xpath/src/lib.nr.
@@ -748,7 +767,7 @@ def parse_datetime(value: str) -> Optional[tuple[int, int]]:
         epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
         utc_dt = py_dt.astimezone(timezone.utc)
         delta = utc_dt - epoch
-        utc_micros = int(delta.total_seconds() * 1_000_000)
+        utc_micros = int(delta.total_seconds() * XSD_MICROS_PER_SECOND)
 
         return (utc_micros, tz_offset_minutes)
     except Exception:
@@ -794,44 +813,29 @@ def parse_duration(value: str) -> Optional[int]:
         day_match = re.search(r"(\d+(?:\.\d+)?)D", date_part)
         if day_match:
             days = float(day_match.group(1))
-            total_micros += int(days * 86_400_000_000)  # 24*60*60*1_000_000
+            total_micros += int(days * XSD_MICROS_PER_DAY)
 
     # Parse time part (hours, minutes, seconds)
     if time_part:
         hour_match = re.search(r"(\d+(?:\.\d+)?)H", time_part)
         if hour_match:
             hours = float(hour_match.group(1))
-            total_micros += int(hours * 3_600_000_000)  # 60*60*1_000_000
+            total_micros += int(hours * XSD_MICROS_PER_HOUR)
 
         min_match = re.search(r"(\d+(?:\.\d+)?)M", time_part)
         if min_match:
             minutes = float(min_match.group(1))
-            total_micros += int(minutes * 60_000_000)  # 60*1_000_000
+            total_micros += int(minutes * XSD_MICROS_PER_MINUTE)
 
         sec_match = re.search(r"(\d+(?:\.\d+)?)S", time_part)
         if sec_match:
             seconds = float(sec_match.group(1))
-            total_micros += int(seconds * 1_000_000)
+            total_micros += int(seconds * XSD_MICROS_PER_SECOND)
 
     if negative:
         total_micros = -total_micros
 
     return total_micros
-
-
-# i64 bounds
-I64_MIN = -9223372036854775808
-I64_MAX = 9223372036854775807
-
-
-def _fits_in_i64(val: int) -> bool:
-    """Check if an integer fits in Noir's i64 range."""
-    return I64_MIN <= val <= I64_MAX
-
-
-def _fits_in_i32(val: int) -> bool:
-    """Check if an integer fits in Noir's i32 range."""
-    return -2147483648 <= val <= 2147483647
 
 
 def parse_year_month_duration(value: str) -> Optional[int]:
@@ -855,7 +859,7 @@ def parse_year_month_duration(value: str) -> Optional[int]:
     months_s = m.group(3)
     years = int(years_s) if years_s is not None else 0
     months = int(months_s) if months_s is not None else 0
-    total = years * 12 + months
+    total = years_months_to_total_months(years, months)
     if neg:
         total = -total
     if not _fits_in_i32(total):
@@ -2580,7 +2584,7 @@ def _datetime_to_epoch(dt: DateTime10) -> Optional[tuple[int, int]]:
         epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
         utc_dt = py_dt.astimezone(timezone.utc)
         delta = utc_dt - epoch
-        utc_micros = int(delta.total_seconds() * 1_000_000)
+        utc_micros = int(delta.total_seconds() * XSD_MICROS_PER_SECOND)
 
         return (utc_micros, tz_offset_minutes)
     except Exception:
@@ -2724,12 +2728,10 @@ def _time_to_microseconds(t: Time) -> Optional[tuple[int, int]]:
             offset = t.tzinfo.offset
             tz_offset_minutes = int(offset.total_seconds() / 60)
 
-        # Calculate microseconds since midnight
-        microseconds = (
-            t.hour * 3600 * 1_000_000
-            + t.minute * 60 * 1_000_000
-            + int(t.second) * 1_000_000
-            + t.microsecond
+        # Calculate microseconds since midnight via the canonical
+        # XSD scaling ladder (see noir_xpath_inputs.constants).
+        microseconds = time_components_to_micros(
+            t.hour, t.minute, int(t.second), t.microsecond
         )
 
         return (microseconds, tz_offset_minutes)
@@ -3024,10 +3026,8 @@ def generate_noir_test(test: TestCase, function_name: str) -> Optional[str]:
                         )
                         assertions.append(f"assert(day_from_date(result) == {day});")
                         if tz_mins is not None:
-                            # timezone_from_date returns XsdDayTimeDuration, compare using duration_equal
-                            tz_micros = (
-                                tz_mins * 60_000_000
-                            )  # Convert minutes to microseconds
+                            # timezone_from_date returns XsdDayTimeDuration; compare using duration_equal
+                            tz_micros = tz_offset_to_micros(tz_mins)
                             assertions.append(
                                 f"assert(duration_equal(timezone_from_date(result), duration_from_microseconds({tz_micros})));"
                             )
@@ -3053,7 +3053,7 @@ def generate_noir_test(test: TestCase, function_name: str) -> Optional[str]:
                         )
                         if tz_mins is not None:
                             # timezone_from_time returns XsdDayTimeDuration
-                            tz_micros = tz_mins * 60_000_000
+                            tz_micros = tz_offset_to_micros(tz_mins)
                             assertions.append(
                                 f"assert(duration_equal(timezone_from_time(result), duration_from_microseconds({tz_micros})));"
                             )
@@ -3092,7 +3092,7 @@ def generate_noir_test(test: TestCase, function_name: str) -> Optional[str]:
                         )
                         if tz_mins is not None:
                             # timezone_from_datetime returns XsdDayTimeDuration
-                            tz_micros = tz_mins * 60_000_000
+                            tz_micros = tz_offset_to_micros(tz_mins)
                             assertions.append(
                                 f"assert(duration_equal(timezone_from_datetime(result), duration_from_microseconds({tz_micros})));"
                             )

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -19,8 +19,6 @@ import re
 import shutil
 import struct
 import subprocess
-import xml.etree.ElementTree as ET
-from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -30,8 +28,16 @@ from typing import Optional
 from elementpath import XPath2Parser
 from elementpath.datatypes import DateTime10, Date10, Time, DayTimeDuration
 
-# XML namespace for qt3tests
-QT3_NS = "{http://www.w3.org/2010/09/qt-fots-catalog}"
+# qt3tests catalogue parser (extracted from this script -- see
+# `scripts/noir_xpath_inputs/qt3tests.py`).
+from noir_xpath_inputs.qt3tests import (
+    QT3_NS,
+    TestCase,
+    clone_or_update_qt3tests,
+    discover_all_test_files,
+    discover_available_functions,
+    parse_test_file,
+)
 
 
 # Cached set of crate-root exports from xpath/src/lib.nr.
@@ -316,52 +322,6 @@ CAST_FUNCTION_PATTERNS = {
 }
 
 
-def discover_available_functions(qt3_dir: Path) -> set[str]:
-    """Discover available function/operator names from qt3tests XML files."""
-    if not qt3_dir.exists():
-        return set()
-    return set(discover_all_test_files(qt3_dir).keys())
-
-
-def discover_all_test_files(
-    qt3_dir: Path, *, include_prod: bool = False
-) -> dict[str, str]:
-    """Discover test files in qt3tests.
-
-    Returns a dict mapping function names (e.g., 'fn:abs', 'op:numeric-add')
-    to their test file paths relative to qt3_dir.
-    """
-    all_functions = {}
-
-    # Discover fn/ test files
-    fn_dir = qt3_dir / "fn"
-    if fn_dir.exists():
-        for xml_file in fn_dir.glob("*.xml"):
-            # Extract function name from filename
-            # e.g., abs.xml -> fn:abs, string-length.xml -> fn:string-length
-            func_name = xml_file.stem
-            all_functions[f"fn:{func_name}"] = f"fn/{xml_file.name}"
-
-    # Discover op/ test files
-    op_dir = qt3_dir / "op"
-    if op_dir.exists():
-        for xml_file in op_dir.glob("*.xml"):
-            # e.g., numeric-add.xml -> op:numeric-add
-            func_name = xml_file.stem
-            all_functions[f"op:{func_name}"] = f"op/{xml_file.name}"
-
-    # Optionally discover prod/ XML files (XQuery/XPath productions).
-    # These are not function/operator tests, but they can be useful for inspection.
-    if include_prod:
-        prod_dir = qt3_dir / "prod"
-        if prod_dir.exists():
-            for xml_file in prod_dir.glob("*.xml"):
-                func_name = xml_file.stem
-                all_functions[f"prod:{func_name}"] = f"prod/{xml_file.name}"
-
-    return all_functions
-
-
 def is_function_implemented(function_name: str) -> bool:
     """Check if a function is implemented by verifying Noir exports.
 
@@ -369,117 +329,6 @@ def is_function_implemented(function_name: str) -> bool:
     exported Noir symbol from the xpath crate root (xpath/src/lib.nr).
     """
     return resolve_noir_symbol(function_name) is not None
-
-
-@dataclass
-class TestCase:
-    """Represents a single test case from qt3tests."""
-
-    name: str
-    description: str
-    test_expr: str
-    expected_result: str
-    result_type: str  # 'assert-eq', 'assert-true', 'assert-false', 'error', etc.
-    dependencies: list = field(default_factory=list)
-
-
-def clone_or_update_qt3tests(qt3_dir: Path) -> None:
-    """Clone or update the qt3tests repository."""
-    if qt3_dir.exists():
-        print(f"qt3tests exists at {qt3_dir}, pulling latest...")
-        subprocess.run(["git", "pull"], cwd=qt3_dir, check=True)
-    else:
-        print(f"Cloning qt3tests to {qt3_dir}...")
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "https://github.com/w3c/qt3tests.git",
-                str(qt3_dir),
-            ],
-            check=True,
-        )
-
-
-def parse_test_file(xml_path: Path) -> list[TestCase]:
-    """Parse a qt3tests XML file and extract test cases."""
-    if not xml_path.exists():
-        print(f"Warning: Test file not found: {xml_path}")
-        return []
-
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-
-    tests = []
-    for test_case in root.findall(f".//{QT3_NS}test-case"):
-        name = test_case.get("name", "unknown")
-
-        # Get dependencies (skip tests with unsupported features)
-        deps = []
-        for dep in test_case.findall(f".//{QT3_NS}dependency"):
-            dep_type = dep.get("type", "")
-            dep_value = dep.get("value", "")
-            deps.append(f"{dep_type}:{dep_value}")
-
-        # Get description
-        desc_elem = test_case.find(f"{QT3_NS}description")
-        description = desc_elem.text if desc_elem is not None and desc_elem.text else ""
-        # Clean up asterisk decorations from qt3tests descriptions
-        import re
-
-        description = re.sub(r"\*+", "", description).strip()
-
-        # Get test expression
-        test_elem = test_case.find(f"{QT3_NS}test")
-        if test_elem is None or test_elem.text is None:
-            continue
-        test_expr = test_elem.text.strip()
-
-        # Get expected result
-        result_elem = test_case.find(f"{QT3_NS}result")
-        if result_elem is None:
-            continue
-
-        # Handle different result types
-        result_type = "unknown"
-        expected_result = ""
-
-        for child in result_elem:
-            tag = child.tag.replace(QT3_NS, "")
-            if tag == "assert-eq":
-                result_type = "assert-eq"
-                expected_result = child.text.strip() if child.text else ""
-            elif tag == "assert-string-value":
-                result_type = "assert-eq"  # Treat same as assert-eq
-                expected_result = child.text.strip() if child.text else ""
-            elif tag == "assert-true":
-                result_type = "assert-true"
-                expected_result = "true"
-            elif tag == "assert-false":
-                result_type = "assert-false"
-                expected_result = "false"
-            elif tag == "error":
-                result_type = "error"
-                expected_result = child.get("code", "")
-            elif tag in ("all-of", "any-of"):
-                result_type = "complex"
-            break
-
-        if result_type not in ("unknown", "complex", "error"):
-            tests.append(
-                TestCase(
-                    name=name,
-                    description=description,
-                    test_expr=test_expr,
-                    expected_result=expected_result,
-                    result_type=result_type,
-                    dependencies=deps,
-                )
-            )
-
-    return tests
 
 
 def sanitize_test_name(name: str) -> str:

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -47,10 +47,11 @@ from noir_xpath_inputs import (
     discover_available_functions,
     fits_in_i32 as _fits_in_i32,
     fits_in_i64 as _fits_in_i64,
+    parse_day_time_duration_micros,
     parse_test_file,
+    parse_year_month_duration_months,
     time_components_to_micros,
     tz_offset_to_micros,
-    years_months_to_total_months,
 )
 
 # i64 / i32 bounds (kept as module-level aliases for the call sites that
@@ -780,62 +781,15 @@ def parse_duration(value: str) -> Optional[int]:
     Returns duration in microseconds (signed integer) or None if parsing fails.
     Format: P[nD][T[nH][nM][n.nS]]
     Examples: "P3DT10H30M", "PT2H30M", "-P2DT4H"
+
+    Independent-extraction note. Per Concern 4 of the input-prep
+    redesign (sec 5), this routes through
+    ``elementpath.datatypes.DayTimeDuration`` (an unrelated XPath
+    library, already a transitive dependency) rather than a hand-
+    rolled regex ladder, so a parser bug shared with the Noir
+    library cannot become invisible.
     """
-    value = value.strip()
-
-    # Handle xs:dayTimeDuration() wrapper
-    match = re.match(r"xs:dayTimeDuration\s*\(['\"]([^'\"]+)['\"]\)", value)
-    if match:
-        value = match.group(1)
-
-    # Check for negative sign
-    negative = value.startswith("-")
-    if negative:
-        value = value[1:]
-
-    # Duration must start with P
-    if not value.startswith("P"):
-        return None
-
-    value = value[1:]  # Remove 'P'
-
-    # Split on 'T' to get date and time parts
-    if "T" in value:
-        date_part, time_part = value.split("T", 1)
-    else:
-        date_part = value
-        time_part = ""
-
-    total_micros = 0
-
-    # Parse date part (days)
-    if date_part:
-        day_match = re.search(r"(\d+(?:\.\d+)?)D", date_part)
-        if day_match:
-            days = float(day_match.group(1))
-            total_micros += int(days * XSD_MICROS_PER_DAY)
-
-    # Parse time part (hours, minutes, seconds)
-    if time_part:
-        hour_match = re.search(r"(\d+(?:\.\d+)?)H", time_part)
-        if hour_match:
-            hours = float(hour_match.group(1))
-            total_micros += int(hours * XSD_MICROS_PER_HOUR)
-
-        min_match = re.search(r"(\d+(?:\.\d+)?)M", time_part)
-        if min_match:
-            minutes = float(min_match.group(1))
-            total_micros += int(minutes * XSD_MICROS_PER_MINUTE)
-
-        sec_match = re.search(r"(\d+(?:\.\d+)?)S", time_part)
-        if sec_match:
-            seconds = float(sec_match.group(1))
-            total_micros += int(seconds * XSD_MICROS_PER_SECOND)
-
-    if negative:
-        total_micros = -total_micros
-
-    return total_micros
+    return parse_day_time_duration_micros(value)
 
 
 def parse_year_month_duration(value: str) -> Optional[int]:
@@ -847,24 +801,12 @@ def parse_year_month_duration(value: str) -> Optional[int]:
     - -P1Y1M
     - P0Y
     - P10M
+
+    Independent-extraction note. Routes through
+    ``elementpath.datatypes.YearMonthDuration`` for the same
+    shared-bug-invisibility reason as ``parse_duration``.
     """
-    s = value.strip()
-    if not s:
-        return None
-    m = re.match(r"^(-)?P(?:(\d+)Y)?(?:(\d+)M)?$", s)
-    if m is None:
-        return None
-    neg = m.group(1) is not None
-    years_s = m.group(2)
-    months_s = m.group(3)
-    years = int(years_s) if years_s is not None else 0
-    months = int(months_s) if months_s is not None else 0
-    total = years_months_to_total_months(years, months)
-    if neg:
-        total = -total
-    if not _fits_in_i32(total):
-        return None
-    return total
+    return parse_year_month_duration_months(value)
 
 
 def _get_function_name(token) -> Optional[str]:

--- a/scripts/noir_xpath_inputs/__init__.py
+++ b/scripts/noir_xpath_inputs/__init__.py
@@ -33,6 +33,10 @@ from .constants import (
     tz_offset_to_micros,
     years_months_to_total_months,
 )
+from .duration import (
+    parse_day_time_duration_micros,
+    parse_year_month_duration_months,
+)
 from .qt3tests import (
     QT3_NS,
     TestCase,
@@ -63,7 +67,9 @@ __all__ = [
     "discover_available_functions",
     "fits_in_i32",
     "fits_in_i64",
+    "parse_day_time_duration_micros",
     "parse_test_file",
+    "parse_year_month_duration_months",
     "time_components_to_micros",
     "tz_offset_to_micros",
     "years_months_to_total_months",

--- a/scripts/noir_xpath_inputs/__init__.py
+++ b/scripts/noir_xpath_inputs/__init__.py
@@ -1,0 +1,32 @@
+"""Helpers for translating XPath qt3tests vectors into noir_XPath inputs.
+
+This package factors out the file-format and bit-pattern logic that
+previously lived inline in ``scripts/generate_tests.py`` so that the
+generator stays focused on Noir-test emission. Mirrors the
+``noir_ieee754_inputs`` package introduced in noir_IEEE754 PR #38.
+
+The submodule layout is:
+
+- :mod:`qt3tests` -- W3C qt3tests catalogue / test-set XML parser
+  (``parse_test_file``, ``discover_all_test_files``,
+  ``clone_or_update_qt3tests``, plus the ``TestCase`` dataclass and
+  the ``QT3_NS`` namespace constant).
+"""
+
+from .qt3tests import (
+    QT3_NS,
+    TestCase,
+    clone_or_update_qt3tests,
+    discover_all_test_files,
+    discover_available_functions,
+    parse_test_file,
+)
+
+__all__ = [
+    "QT3_NS",
+    "TestCase",
+    "clone_or_update_qt3tests",
+    "discover_all_test_files",
+    "discover_available_functions",
+    "parse_test_file",
+]

--- a/scripts/noir_xpath_inputs/__init__.py
+++ b/scripts/noir_xpath_inputs/__init__.py
@@ -13,6 +13,26 @@ The submodule layout is:
   the ``QT3_NS`` namespace constant).
 """
 
+from .constants import (
+    XSD_INTEGER_I32_MAX,
+    XSD_INTEGER_I32_MIN,
+    XSD_INTEGER_I64_MAX,
+    XSD_INTEGER_I64_MIN,
+    XSD_MICROS_PER_DAY,
+    XSD_MICROS_PER_HOUR,
+    XSD_MICROS_PER_MINUTE,
+    XSD_MICROS_PER_SECOND,
+    XSD_MONTHS_PER_YEAR,
+    XSD_QNAME_MAX_LOCAL_LEN,
+    XSD_QNAME_MAX_NS_LEN,
+    XSD_TZ_MAX_MINUTES,
+    XSD_TZ_MIN_MINUTES,
+    fits_in_i32,
+    fits_in_i64,
+    time_components_to_micros,
+    tz_offset_to_micros,
+    years_months_to_total_months,
+)
 from .qt3tests import (
     QT3_NS,
     TestCase,
@@ -25,8 +45,26 @@ from .qt3tests import (
 __all__ = [
     "QT3_NS",
     "TestCase",
+    "XSD_INTEGER_I32_MAX",
+    "XSD_INTEGER_I32_MIN",
+    "XSD_INTEGER_I64_MAX",
+    "XSD_INTEGER_I64_MIN",
+    "XSD_MICROS_PER_DAY",
+    "XSD_MICROS_PER_HOUR",
+    "XSD_MICROS_PER_MINUTE",
+    "XSD_MICROS_PER_SECOND",
+    "XSD_MONTHS_PER_YEAR",
+    "XSD_QNAME_MAX_LOCAL_LEN",
+    "XSD_QNAME_MAX_NS_LEN",
+    "XSD_TZ_MAX_MINUTES",
+    "XSD_TZ_MIN_MINUTES",
     "clone_or_update_qt3tests",
     "discover_all_test_files",
     "discover_available_functions",
+    "fits_in_i32",
+    "fits_in_i64",
     "parse_test_file",
+    "time_components_to_micros",
+    "tz_offset_to_micros",
+    "years_months_to_total_months",
 ]

--- a/scripts/noir_xpath_inputs/constants.py
+++ b/scripts/noir_xpath_inputs/constants.py
@@ -1,0 +1,100 @@
+"""Hand-written Python mirrors of `xpath::constants` (Noir).
+
+This module is the Python-side single source of truth for the magic
+numbers that XPath / XML Schema datatype arithmetic touches. Each
+constant mirrors a `pub global` exported by the Noir library's
+`xpath/src/constants.nr` so the test generator stops re-deriving the
+same `86_400_000_000` / `60_000_000` / `9_223_372_036_854_775_808`
+literals that already live in the library it targets.
+
+Mirrors `noir_ieee754_inputs.constants` (introduced by noir_IEEE754
+PR #38), with XSD-type-bounds + timezone-related constants standing
+in for the IEEE 754 mask + min/max constants in that repo.
+
+Once the workspace input-prep crate (`tools/noir-xpath-inputs-py/`,
+phase 1 of `docs/xpath-input-prep-redesign.md`) lands, this module
+will be auto-generated from `xpath/src/constants.nr` doc-comments
+and imported here as a re-export. Until then, edits to either side
+must be kept in sync by hand.
+"""
+
+from __future__ import annotations
+
+# ============================================================================
+# Microsecond scaling ladder (mirrors `pub global XSD_MICROS_PER_*` in
+# xpath/src/constants.nr)
+# ============================================================================
+
+XSD_MICROS_PER_SECOND: int = 1_000_000
+XSD_MICROS_PER_MINUTE: int = 60_000_000
+XSD_MICROS_PER_HOUR: int = 3_600_000_000
+XSD_MICROS_PER_DAY: int = 86_400_000_000
+
+# ============================================================================
+# Year/month conversion (W3C XML Schema Part 2 sec 3.2.6 yearMonthDuration)
+# ============================================================================
+
+XSD_MONTHS_PER_YEAR: int = 12
+
+# ============================================================================
+# Timezone offset bounds (W3C XML Schema Part 2 sec 3.2.7.3)
+# ============================================================================
+
+XSD_TZ_MIN_MINUTES: int = -840  # -14:00
+XSD_TZ_MAX_MINUTES: int = 840  # +14:00
+
+# ============================================================================
+# Integer bounds (XPath F&O xs:integer is unbounded; Noir storage is i64)
+# ============================================================================
+
+XSD_INTEGER_I32_MIN: int = -2_147_483_648
+XSD_INTEGER_I32_MAX: int = 2_147_483_647
+XSD_INTEGER_I64_MIN: int = -9_223_372_036_854_775_808
+XSD_INTEGER_I64_MAX: int = 9_223_372_036_854_775_807
+
+# ============================================================================
+# QName component buffer sizes
+# ============================================================================
+
+XSD_QNAME_MAX_NS_LEN: int = 256
+XSD_QNAME_MAX_LOCAL_LEN: int = 128
+
+
+# ============================================================================
+# Helper functions (small, pure-stdlib) -- the Python mirrors of common
+# packing operations the Noir library does internally. Calling these
+# instead of inlining the arithmetic centralises the constant references.
+# ============================================================================
+
+
+def fits_in_i64(val: int) -> bool:
+    """Whether ``val`` fits in Noir's signed 64-bit integer."""
+    return XSD_INTEGER_I64_MIN <= val <= XSD_INTEGER_I64_MAX
+
+
+def fits_in_i32(val: int) -> bool:
+    """Whether ``val`` fits in Noir's signed 32-bit integer."""
+    return XSD_INTEGER_I32_MIN <= val <= XSD_INTEGER_I32_MAX
+
+
+def tz_offset_to_micros(tz_minutes: int) -> int:
+    """Convert a timezone offset (in minutes) to microseconds."""
+    return tz_minutes * XSD_MICROS_PER_MINUTE
+
+
+def time_components_to_micros(
+    hours: int, minutes: int, seconds: int, microseconds: int = 0
+) -> int:
+    """Convert (hours, minutes, seconds, microseconds) to microseconds
+    since midnight, using the canonical XSD scaling ladder."""
+    return (
+        hours * XSD_MICROS_PER_HOUR
+        + minutes * XSD_MICROS_PER_MINUTE
+        + seconds * XSD_MICROS_PER_SECOND
+        + microseconds
+    )
+
+
+def years_months_to_total_months(years: int, months: int) -> int:
+    """Convert (years, months) to total months."""
+    return years * XSD_MONTHS_PER_YEAR + months

--- a/scripts/noir_xpath_inputs/duration.py
+++ b/scripts/noir_xpath_inputs/duration.py
@@ -1,0 +1,94 @@
+"""Independent-extraction routes for xs:dayTimeDuration / xs:yearMonthDuration.
+
+Per Concern 4 of `docs/xpath-input-prep-redesign.md` (sec 5), the test
+generator's hand-rolled regex parsers for ISO 8601 durations are
+shared-bug-invisible: if both the Noir library and the Python test
+vectors derive their micro-second / total-month encoding from the
+same regex ladder, a parser bug would not be caught.
+
+This module routes parsing through ``elementpath.datatypes`` -- which
+``noir_XPath`` already depends on transitively -- so the test
+generator's reference path runs through CPython + an unrelated XPath
+library rather than through code that resembles the Noir library
+under test.
+
+Mirrors the noir_IEEE754 PR #38 phase-2c pattern (commit 2d957fe:
+``refactor(tests): independent bit extraction via float.fromhex +
+struct``) where bit extraction was rerouted through ``float.fromhex``
++ ``struct.pack`` instead of a hand-rolled significand ladder.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from typing import Optional
+
+from elementpath.datatypes import DayTimeDuration, YearMonthDuration
+
+from .constants import XSD_MICROS_PER_SECOND, fits_in_i32
+
+# Strip an optional ``xs:dayTimeDuration("...")`` / ``xs:yearMonthDuration("...")``
+# wrapper before handing the literal to elementpath.
+_DAYTIME_WRAPPER_RE = re.compile(r"xs:dayTimeDuration\s*\(['\"]([^'\"]+)['\"]\)")
+_YEARMONTH_WRAPPER_RE = re.compile(r"xs:yearMonthDuration\s*\(['\"]([^'\"]+)['\"]\)")
+
+
+def _strip_wrapper(value: str, pattern: re.Pattern[str]) -> str:
+    """Strip an optional XPath constructor wrapper from a literal."""
+    match = pattern.match(value.strip())
+    if match is not None:
+        return match.group(1)
+    return value.strip()
+
+
+def parse_day_time_duration_micros(value: str) -> Optional[int]:
+    """Parse an XPath ``xs:dayTimeDuration`` literal into signed
+    microseconds, via ``elementpath.datatypes.DayTimeDuration``.
+
+    ``elementpath`` ships its own ISO 8601 duration validator; on a
+    parse error we return ``None`` to match the historical regex
+    parser's contract.
+
+    Returns ``None`` for empty input, an unparseable literal, or a
+    duration whose microsecond representation overflows i64 (the
+    caller decides whether to skip the test).
+    """
+    if value is None:
+        return None
+    raw = _strip_wrapper(value, _DAYTIME_WRAPPER_RE)
+    if not raw:
+        return None
+    try:
+        dur = DayTimeDuration.fromstring(raw)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+    # ``DayTimeDuration.seconds`` is a Decimal -- exact for the lexical
+    # forms qt3tests uses (no float-rounding loss). Multiplying by
+    # XSD_MICROS_PER_SECOND keeps the conversion in Decimal arithmetic.
+    seconds: Decimal = dur.seconds
+    total_micros = int(seconds * Decimal(XSD_MICROS_PER_SECOND))
+    return total_micros
+
+
+def parse_year_month_duration_months(value: str) -> Optional[int]:
+    """Parse an XPath ``xs:yearMonthDuration`` literal into signed
+    total months (i32), via ``elementpath.datatypes.YearMonthDuration``.
+
+    Returns ``None`` for empty input, unparseable literals, or values
+    whose total-month count exceeds i32.
+    """
+    if value is None:
+        return None
+    raw = _strip_wrapper(value, _YEARMONTH_WRAPPER_RE)
+    if not raw:
+        return None
+    try:
+        dur = YearMonthDuration.fromstring(raw)
+    except (ValueError, TypeError, OverflowError):
+        return None
+    months: int = int(dur.months)
+    if not fits_in_i32(months):
+        return None
+    return months

--- a/scripts/noir_xpath_inputs/duration.py
+++ b/scripts/noir_xpath_inputs/duration.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from elementpath.datatypes import DayTimeDuration, YearMonthDuration
 
-from .constants import XSD_MICROS_PER_SECOND, fits_in_i32
+from .constants import XSD_MICROS_PER_SECOND, fits_in_i32, fits_in_i64
 
 # Strip an optional ``xs:dayTimeDuration("...")`` / ``xs:yearMonthDuration("...")``
 # wrapper before handing the literal to elementpath.
@@ -69,6 +69,12 @@ def parse_day_time_duration_micros(value: str) -> Optional[int]:
     # XSD_MICROS_PER_SECOND keeps the conversion in Decimal arithmetic.
     seconds: Decimal = dur.seconds
     total_micros = int(seconds * Decimal(XSD_MICROS_PER_SECOND))
+    # Match ``parse_year_month_duration_months`` -- the Noir storage is
+    # i64, and downstream emitters can't represent values outside that
+    # range; return ``None`` so the caller skips the test rather than
+    # carry an arbitrary-precision Python int through to a packing site.
+    if not fits_in_i64(total_micros):
+        return None
     return total_micros
 
 

--- a/scripts/noir_xpath_inputs/qt3tests.py
+++ b/scripts/noir_xpath_inputs/qt3tests.py
@@ -1,0 +1,205 @@
+"""W3C qt3tests catalogue / test-set XML parser.
+
+This module owns the file-format logic for the qt3tests test suite
+(<https://github.com/w3c/qt3tests>) so the test generator stays focused
+on Noir-test emission.
+
+A reusable upstream parser exists in
+`sissaschool/elementpath`'s `tests/run_w3c_tests.py` (MIT, the same
+project ``elementpath`` we already depend on -- see the noir_XPath
+input-prep redesign sec 2). However, that file is not shipped in the
+installed ``elementpath`` package and ships as a stand-alone test
+runner with elementpath-conformance allow-lists baked in. Per the
+redesign doc the eventual fork-and-extract is a workspace-level lift
+(``tools/noir-test-vectors/qt3tests.py``); this module is the
+intermediate per-repo extraction that keeps the noir_XPath generator
+script clean while we wait for the workspace lift to land.
+
+Coverage matches the previous in-line implementation: ``test-case``
+elements, ``description`` (with asterisk decoration stripped),
+``dependency`` collection, the ``test`` expression body and the
+common single-child result assertions (``assert-eq`` /
+``assert-string-value`` / ``assert-true`` / ``assert-false`` /
+``error``). Composite ``all-of`` / ``any-of`` results are flagged but
+not expanded -- the generator skips those.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# XML namespace for the QT3 test-suite catalogue and per-test-set files.
+QT3_NS = "{http://www.w3.org/2010/09/qt-fots-catalog}"
+
+
+@dataclass
+class TestCase:
+    """A single ``<test-case>`` extracted from a qt3tests XML file.
+
+    Mirrors the historical in-line shape used by ``generate_tests.py``;
+    in particular ``result_type`` is the assertion tag's local name
+    (``assert-eq`` / ``assert-true`` / ``assert-false`` / ``error`` /
+    ``complex``) and ``expected_result`` is the assertion's text
+    content (or, for ``error``, the ``code`` attribute).
+    """
+
+    name: str
+    description: str
+    test_expr: str
+    expected_result: str
+    # 'assert-eq', 'assert-true', 'assert-false', 'error', 'complex' or 'unknown'
+    result_type: str
+    dependencies: list = field(default_factory=list)
+
+
+def parse_test_file(xml_path: Path) -> list[TestCase]:
+    """Parse a qt3tests XML file and extract its test cases.
+
+    Returns an empty list (with a stderr warning) if the path does not
+    exist; a missing file is the qt3tests-not-cloned-yet path that
+    ``clone_or_update_qt3tests`` resolves separately.
+    """
+    if not xml_path.exists():
+        print(f"Warning: Test file not found: {xml_path}")
+        return []
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    tests: list[TestCase] = []
+    for test_case in root.findall(f".//{QT3_NS}test-case"):
+        name = test_case.get("name", "unknown")
+
+        # Get dependencies (caller decides which ones to skip).
+        deps: list[str] = []
+        for dep in test_case.findall(f".//{QT3_NS}dependency"):
+            dep_type = dep.get("type", "")
+            dep_value = dep.get("value", "")
+            deps.append(f"{dep_type}:{dep_value}")
+
+        # Get description (qt3tests sometimes wraps it in asterisks).
+        desc_elem = test_case.find(f"{QT3_NS}description")
+        description = (
+            desc_elem.text if desc_elem is not None and desc_elem.text else ""
+        )
+        description = re.sub(r"\*+", "", description).strip()
+
+        # Get test expression
+        test_elem = test_case.find(f"{QT3_NS}test")
+        if test_elem is None or test_elem.text is None:
+            continue
+        test_expr = test_elem.text.strip()
+
+        # Get expected result
+        result_elem = test_case.find(f"{QT3_NS}result")
+        if result_elem is None:
+            continue
+
+        # Handle different result types.
+        result_type = "unknown"
+        expected_result = ""
+
+        for child in result_elem:
+            tag = child.tag.replace(QT3_NS, "")
+            if tag == "assert-eq":
+                result_type = "assert-eq"
+                expected_result = child.text.strip() if child.text else ""
+            elif tag == "assert-string-value":
+                result_type = "assert-eq"  # treat as assert-eq downstream
+                expected_result = child.text.strip() if child.text else ""
+            elif tag == "assert-true":
+                result_type = "assert-true"
+                expected_result = "true"
+            elif tag == "assert-false":
+                result_type = "assert-false"
+                expected_result = "false"
+            elif tag == "error":
+                result_type = "error"
+                expected_result = child.get("code", "")
+            elif tag in ("all-of", "any-of"):
+                result_type = "complex"
+            break
+
+        if result_type not in ("unknown", "complex", "error"):
+            tests.append(
+                TestCase(
+                    name=name,
+                    description=description,
+                    test_expr=test_expr,
+                    expected_result=expected_result,
+                    result_type=result_type,
+                    dependencies=deps,
+                )
+            )
+
+    return tests
+
+
+def discover_all_test_files(
+    qt3_dir: Path, *, include_prod: bool = False
+) -> dict[str, str]:
+    """Discover test files in a local qt3tests checkout.
+
+    Returns a dict mapping function names (e.g. ``fn:abs``,
+    ``op:numeric-add``) to their test file paths relative to
+    ``qt3_dir``. With ``include_prod=True`` the dict also includes
+    XPath / XQuery production fixtures under ``prod/`` keyed as
+    ``prod:<stem>``.
+    """
+    all_functions: dict[str, str] = {}
+
+    fn_dir = qt3_dir / "fn"
+    if fn_dir.exists():
+        for xml_file in fn_dir.glob("*.xml"):
+            func_name = xml_file.stem
+            all_functions[f"fn:{func_name}"] = f"fn/{xml_file.name}"
+
+    op_dir = qt3_dir / "op"
+    if op_dir.exists():
+        for xml_file in op_dir.glob("*.xml"):
+            func_name = xml_file.stem
+            all_functions[f"op:{func_name}"] = f"op/{xml_file.name}"
+
+    if include_prod:
+        prod_dir = qt3_dir / "prod"
+        if prod_dir.exists():
+            for xml_file in prod_dir.glob("*.xml"):
+                func_name = xml_file.stem
+                all_functions[f"prod:{func_name}"] = f"prod/{xml_file.name}"
+
+    return all_functions
+
+
+def discover_available_functions(qt3_dir: Path) -> set[str]:
+    """Return the set of qt3tests function/operator names with XML
+    fixtures under ``qt3_dir``.
+
+    Empty if the directory does not exist (qt3tests not yet cloned).
+    """
+    if not qt3_dir.exists():
+        return set()
+    return set(discover_all_test_files(qt3_dir).keys())
+
+
+def clone_or_update_qt3tests(qt3_dir: Path) -> None:
+    """Clone (shallow) or ``git pull`` an existing qt3tests checkout."""
+    if qt3_dir.exists():
+        print(f"qt3tests exists at {qt3_dir}, pulling latest...")
+        subprocess.run(["git", "pull"], cwd=qt3_dir, check=True)
+    else:
+        print(f"Cloning qt3tests to {qt3_dir}...")
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "https://github.com/w3c/qt3tests.git",
+                str(qt3_dir),
+            ],
+            check=True,
+        )

--- a/xpath/src/constants.nr
+++ b/xpath/src/constants.nr
@@ -1,0 +1,85 @@
+//! XPath / XML Schema datatype constants.
+//!
+//! Single source of truth for the magic numbers that appear in XPath
+//! datatype arithmetic, timezone validation, integer-bound checks and
+//! QName buffer sizing. Per the noir_XPath input-prep redesign (sec 3),
+//! these were previously duplicated across `duration.nr`, `datetime.nr`,
+//! `time.nr`, `types.nr` and `qname.nr`; this module is the canonical
+//! home so the test generator (and any future codegen) can mirror the
+//! exact same names without re-deriving them.
+//!
+//! Conventions:
+//! - `XSD_MICROS_PER_*` -- microsecond scaling ladder shared by
+//!   `xs:dateTime`, `xs:date`, `xs:time` and `xs:dayTimeDuration`.
+//! - `XSD_MONTHS_PER_YEAR` -- conversion factor used by
+//!   `xs:yearMonthDuration` (W3C XML Schema Part 2, sec 3.2.6).
+//! - `XSD_TZ_*_MINUTES` -- canonical timezone offset bounds (W3C XML
+//!   Schema Part 2, sec 3.2.7.3: -14:00 to +14:00).
+//! - `XSD_INTEGER_I{32,64}_{MIN,MAX}` -- integer bounds for the i32
+//!   and i64 storage backings the test generator emits. XPath F&O
+//!   `xs:integer` is unbounded, but Noir storage is i64 and
+//!   `xs:yearMonthDuration::total_months` is i32.
+//! - `XSD_QNAME_MAX_*_LEN` -- byte-buffer sizes for QName components.
+
+// ============================================================================
+// Microsecond scaling ladder (u64; cast to i64 at call sites in duration.nr)
+// ============================================================================
+
+/// Microseconds in one SI second.
+pub global XSD_MICROS_PER_SECOND: u64 = 1_000_000;
+
+/// Microseconds in one minute (60 seconds).
+pub global XSD_MICROS_PER_MINUTE: u64 = 60_000_000;
+
+/// Microseconds in one hour (60 minutes).
+pub global XSD_MICROS_PER_HOUR: u64 = 3_600_000_000;
+
+/// Microseconds in one day (24 hours).
+pub global XSD_MICROS_PER_DAY: u64 = 86_400_000_000;
+
+// ============================================================================
+// Year/month conversion (W3C XML Schema Part 2 sec 3.2.6 yearMonthDuration)
+// ============================================================================
+
+/// Months in one Gregorian year (used by xs:yearMonthDuration).
+pub global XSD_MONTHS_PER_YEAR: u32 = 12;
+
+// ============================================================================
+// Timezone offset bounds (W3C XML Schema Part 2 sec 3.2.7.3)
+// ============================================================================
+
+/// Minimum legal timezone offset for XML Schema dateTime / date / time
+/// values (-14:00).
+pub global XSD_TZ_MIN_MINUTES: i16 = -840;
+
+/// Maximum legal timezone offset for XML Schema dateTime / date / time
+/// values (+14:00).
+pub global XSD_TZ_MAX_MINUTES: i16 = 840;
+
+// ============================================================================
+// Integer bounds (XPath F&O xs:integer is unbounded; Noir storage is i64)
+// ============================================================================
+
+/// Minimum value representable by Noir's signed 32-bit integer (used by
+/// xs:yearMonthDuration::total_months).
+pub global XSD_INTEGER_I32_MIN: i32 = -2_147_483_648;
+
+/// Maximum value representable by Noir's signed 32-bit integer.
+pub global XSD_INTEGER_I32_MAX: i32 = 2_147_483_647;
+
+/// Minimum value representable by Noir's signed 64-bit integer (used as
+/// the storage cap on xs:integer / xs:dayTimeDuration microseconds).
+pub global XSD_INTEGER_I64_MIN: i64 = -9_223_372_036_854_775_808;
+
+/// Maximum value representable by Noir's signed 64-bit integer.
+pub global XSD_INTEGER_I64_MAX: i64 = 9_223_372_036_854_775_807;
+
+// ============================================================================
+// QName component buffer sizes
+// ============================================================================
+
+/// Maximum namespace URI length, in bytes, supported by the QName type.
+pub global XSD_QNAME_MAX_NS_LEN: u32 = 256;
+
+/// Maximum local-name length, in bytes, supported by the QName type.
+pub global XSD_QNAME_MAX_LOCAL_LEN: u32 = 128;

--- a/xpath/src/date.nr
+++ b/xpath/src/date.nr
@@ -8,6 +8,7 @@
 //! - fn:timezone-from-date
 //! - op:date-equal, op:date-less-than, op:date-greater-than
 
+use crate::constants::{XSD_MICROS_PER_DAY, XSD_MICROS_PER_MINUTE};
 use crate::types::{XsdDate, XsdDayTimeDuration};
 
 // ============================================================================
@@ -71,7 +72,7 @@ pub fn day_from_date(date: XsdDate) -> u8 {
 
 /// Extract timezone from date as a dayTimeDuration
 pub fn timezone_from_date(date: XsdDate) -> XsdDayTimeDuration {
-    let offset_micros: i64 = (date.tz_offset_minutes as i64) * 60_000_000; // 60 * 1_000_000
+    let offset_micros: i64 = (date.tz_offset_minutes as i64) * (XSD_MICROS_PER_MINUTE as i64);
     XsdDayTimeDuration::from_signed_micros(offset_micros)
 }
 
@@ -253,7 +254,7 @@ fn test_date_roundtrip_various_samples() {
 pub fn date_add_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate {
     let dur_micros = dur.to_signed_micros();
     // Convert microseconds to days (integer division)
-    let dur_days: i32 = (dur_micros / 86_400_000_000) as i32;
+    let dur_days: i32 = (dur_micros / (XSD_MICROS_PER_DAY as i64)) as i32;
     let new_days = date.epoch_days + dur_days;
     XsdDate::new_with_tz(new_days, date.tz_offset_minutes)
 }
@@ -263,7 +264,7 @@ pub fn date_add_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate {
 pub fn date_subtract_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate {
     let dur_micros = dur.to_signed_micros();
     // Convert microseconds to days (integer division)
-    let dur_days: i32 = (dur_micros / 86_400_000_000) as i32;
+    let dur_days: i32 = (dur_micros / (XSD_MICROS_PER_DAY as i64)) as i32;
     let new_days = date.epoch_days - dur_days;
     XsdDate::new_with_tz(new_days, date.tz_offset_minutes)
 }
@@ -272,7 +273,7 @@ pub fn date_subtract_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate
 /// Returns the dayTimeDuration between two dates (a - b)
 pub fn subtract_dates(a: XsdDate, b: XsdDate) -> XsdDayTimeDuration {
     let day_diff = a.epoch_days - b.epoch_days;
-    let micros: i64 = (day_diff as i64) * 86_400_000_000;
+    let micros: i64 = (day_diff as i64) * (XSD_MICROS_PER_DAY as i64);
     XsdDayTimeDuration::from_signed_micros(micros)
 }
 
@@ -303,7 +304,7 @@ pub fn adjust_date_to_timezone_none(date: XsdDate) -> XsdDate {
 /// Both must have the same timezone (or both have no timezone)
 pub fn fn_dateTime(date: XsdDate, time: crate::types::XsdTime) -> crate::types::XsdDateTime {
     // Convert date to epoch microseconds (at midnight)
-    let date_micros: i64 = (date.epoch_days as i64) * 86_400_000_000;
+    let date_micros: i64 = (date.epoch_days as i64) * (XSD_MICROS_PER_DAY as i64);
     // Add time microseconds
     let total_micros: i64 = date_micros + time.microseconds_since_midnight as i64;
     // Convert to unsigned for Field

--- a/xpath/src/datetime.nr
+++ b/xpath/src/datetime.nr
@@ -10,24 +10,17 @@
 //! - fn:hours-from-dateTime, fn:minutes-from-dateTime, fn:seconds-from-dateTime
 //! - op:dateTime-equal, op:dateTime-less-than, op:dateTime-greater-than
 
+use crate::constants::{
+    XSD_MICROS_PER_DAY as MICROSECONDS_PER_DAY, XSD_MICROS_PER_HOUR as MICROSECONDS_PER_HOUR,
+    XSD_MICROS_PER_MINUTE as MICROSECONDS_PER_MINUTE,
+    XSD_MICROS_PER_SECOND as MICROSECONDS_PER_SECOND,
+};
 use crate::duration::duration_from_microseconds;
 use crate::types::XsdDateTime;
 
-// ============================================================================
-// Time Constants (as u64 for arithmetic)
-// ============================================================================
-
-/// Microseconds per second
-global MICROSECONDS_PER_SECOND: u64 = 1_000_000;
-
-/// Microseconds per minute
-global MICROSECONDS_PER_MINUTE: u64 = 60_000_000;
-
-/// Microseconds per hour
-global MICROSECONDS_PER_HOUR: u64 = 3_600_000_000;
-
-/// Microseconds per day
-global MICROSECONDS_PER_DAY: u64 = 86_400_000_000;
+// Microsecond scaling ladder is sourced from `crate::constants` -- see
+// `xpath/src/constants.nr`. The local `MICROSECONDS_PER_*` aliases above
+// preserve the existing in-module names for the call sites below.
 
 // ============================================================================
 // Construction Functions
@@ -100,7 +93,7 @@ pub fn datetime_from_components_with_tz(
     let local_micros: u64 = (days as u64) * MICROSECONDS_PER_DAY + time_micros;
 
     // Convert to UTC by subtracting the timezone offset
-    let offset_micros: i64 = (tz_offset_minutes as i64) * 60_000_000;
+    let offset_micros: i64 = (tz_offset_minutes as i64) * (MICROSECONDS_PER_MINUTE as i64);
     let utc_micros: i64 = (local_micros as i64) - offset_micros;
     let utc_u64: u64 = utc_micros as u64;
 
@@ -122,7 +115,7 @@ pub fn datetime_timezone_offset(dt: XsdDateTime) -> i16 {
 /// Returns the timezone offset as a duration (e.g., -PT5H for -05:00)
 pub fn timezone_from_datetime(dt: XsdDateTime) -> crate::types::XsdDayTimeDuration {
     let offset_minutes = dt.tz_offset_minutes as i64;
-    let offset_micros = offset_minutes * 60_000_000; // Convert minutes to microseconds
+    let offset_micros = offset_minutes * (MICROSECONDS_PER_MINUTE as i64);
     duration_from_microseconds(offset_micros)
 }
 

--- a/xpath/src/duration.nr
+++ b/xpath/src/duration.nr
@@ -9,23 +9,29 @@
 //! - op:add-dayTimeDuration-to-dateTime, op:subtract-dayTimeDuration-from-dateTime
 //! - op:dayTimeDuration-equal, op:dayTimeDuration-less-than, op:dayTimeDuration-greater-than
 
+use crate::constants::{
+    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR, XSD_MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND,
+};
 use crate::types::{XsdDateTime, XsdDayTimeDuration};
 
 // ============================================================================
-// Time Constants (as i64 for signed arithmetic)
+// Time Constants (signed-i64 aliases of the canonical u64 constants in
+// `crate::constants`. Sign-extending the u64 globals at compile time
+// keeps the duration arithmetic below in i64 without re-declaring the
+// magic numbers.)
 // ============================================================================
 
-/// Microseconds per second
-global MICROS_PER_SECOND: i64 = 1_000_000;
+/// Microseconds per second.
+global MICROS_PER_SECOND: i64 = XSD_MICROS_PER_SECOND as i64;
 
-/// Microseconds per minute
-global MICROS_PER_MINUTE: i64 = 60_000_000;
+/// Microseconds per minute.
+global MICROS_PER_MINUTE: i64 = XSD_MICROS_PER_MINUTE as i64;
 
-/// Microseconds per hour
-global MICROS_PER_HOUR: i64 = 3_600_000_000;
+/// Microseconds per hour.
+global MICROS_PER_HOUR: i64 = XSD_MICROS_PER_HOUR as i64;
 
-/// Microseconds per day
-global MICROS_PER_DAY: i64 = 86_400_000_000;
+/// Microseconds per day.
+global MICROS_PER_DAY: i64 = XSD_MICROS_PER_DAY as i64;
 
 // ============================================================================
 // Duration Construction Functions
@@ -271,7 +277,7 @@ fn test_datetime_duration_arithmetic() {
 
     // Add one day
     let dt_plus = datetime_add_duration(dt, one_day);
-    let expected_micros: Field = 86_400_000_000;
+    let expected_micros: Field = XSD_MICROS_PER_DAY as Field;
     assert(dt_plus.epoch_microseconds == expected_micros);
 
     // Subtract back

--- a/xpath/src/lib.nr
+++ b/xpath/src/lib.nr
@@ -34,6 +34,7 @@
 //! ```
 
 // Internal implementation modules
+mod constants;
 mod types;
 mod boolean;
 mod numeric;
@@ -63,6 +64,16 @@ pub mod unconstrained_ops;
 pub mod xpath_fn;
 pub mod xpath_op;
 pub mod xpath_xs;
+
+// Re-export XSD type / arithmetic constants (single source of truth -- see
+// `xpath/src/constants.nr`). Test generators and downstream consumers
+// reference these by name instead of reconstructing the magic numbers.
+pub use constants::{
+    XSD_INTEGER_I32_MAX, XSD_INTEGER_I32_MIN, XSD_INTEGER_I64_MAX, XSD_INTEGER_I64_MIN,
+    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR, XSD_MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND,
+    XSD_MONTHS_PER_YEAR, XSD_QNAME_MAX_LOCAL_LEN, XSD_QNAME_MAX_NS_LEN, XSD_TZ_MAX_MINUTES,
+    XSD_TZ_MIN_MINUTES,
+};
 
 // Re-export types
 pub use types::{XsdDate, XsdDateTime, XsdDayTimeDuration, XsdTime};

--- a/xpath/src/qname.nr
+++ b/xpath/src/qname.nr
@@ -10,11 +10,12 @@
 // QName Type
 // ============================================================================
 
-/// Maximum length for namespace URI in bytes
-global MAX_NAMESPACE_LEN: u32 = 256;
-
-/// Maximum length for local name in bytes
-global MAX_LOCALNAME_LEN: u32 = 128;
+// QName component buffer sizes are sourced from `crate::constants` --
+// see `xpath/src/constants.nr`. The aliases below preserve the existing
+// in-module names for the call sites below.
+use crate::constants::{
+    XSD_QNAME_MAX_LOCAL_LEN as MAX_LOCALNAME_LEN, XSD_QNAME_MAX_NS_LEN as MAX_NAMESPACE_LEN,
+};
 
 /// XSD QName representation
 /// A qualified name consists of a namespace URI and a local name

--- a/xpath/src/time.nr
+++ b/xpath/src/time.nr
@@ -8,15 +8,15 @@
 //! - fn:timezone-from-time
 //! - op:time-equal, op:time-less-than, op:time-greater-than
 
+use crate::constants::{
+    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR as MICROS_PER_HOUR,
+    XSD_MICROS_PER_MINUTE as MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND as MICROS_PER_SECOND,
+};
 use crate::types::{XsdDayTimeDuration, XsdTime};
 
-// ============================================================================
-// Time Constants
-// ============================================================================
-
-global MICROS_PER_SECOND: u64 = 1_000_000;
-global MICROS_PER_MINUTE: u64 = 60_000_000;
-global MICROS_PER_HOUR: u64 = 3_600_000_000;
+// Microsecond scaling ladder is sourced from `crate::constants` -- see
+// `xpath/src/constants.nr`. The local `MICROS_PER_*` aliases above
+// preserve the existing in-module names for the call sites below.
 
 // ============================================================================
 // Time Construction Functions
@@ -86,7 +86,7 @@ pub fn microseconds_from_time(time: XsdTime) -> u32 {
 
 /// fn:timezone-from-time - Extract timezone as a dayTimeDuration
 pub fn timezone_from_time(time: XsdTime) -> XsdDayTimeDuration {
-    let offset_micros: i64 = (time.tz_offset_minutes as i64) * 60_000_000;
+    let offset_micros: i64 = (time.tz_offset_minutes as i64) * (MICROS_PER_MINUTE as i64);
     XsdDayTimeDuration::from_signed_micros(offset_micros)
 }
 
@@ -134,7 +134,7 @@ pub fn subtract_times(a: XsdTime, b: XsdTime) -> XsdDayTimeDuration {
 pub fn time_add_duration(time: XsdTime, dur: XsdDayTimeDuration) -> XsdTime {
     let time_micros = time.microseconds_since_midnight as i64;
     let dur_micros = dur.to_signed_micros();
-    let day_micros: i64 = 86_400_000_000;
+    let day_micros: i64 = XSD_MICROS_PER_DAY as i64;
 
     // Add duration and normalize to 0-24 hour range
     let result = time_micros + dur_micros;
@@ -147,7 +147,7 @@ pub fn time_add_duration(time: XsdTime, dur: XsdDayTimeDuration) -> XsdTime {
 pub fn time_subtract_duration(time: XsdTime, dur: XsdDayTimeDuration) -> XsdTime {
     let time_micros = time.microseconds_since_midnight as i64;
     let dur_micros = dur.to_signed_micros();
-    let day_micros: i64 = 86_400_000_000;
+    let day_micros: i64 = XSD_MICROS_PER_DAY as i64;
 
     // Subtract duration and normalize to 0-24 hour range
     let result = time_micros - dur_micros;
@@ -167,9 +167,9 @@ pub fn adjust_time_to_timezone(time: XsdTime, new_tz_offset_minutes: i16) -> Xsd
     let utc_micros = time.utc_microseconds();
     // Create a new time with the new timezone, adjusting for the offset difference
     let offset_diff = new_tz_offset_minutes as i64 - time.tz_offset_minutes as i64;
-    let new_local_micros = utc_micros + offset_diff * 60_000_000;
+    let new_local_micros = utc_micros + offset_diff * (MICROS_PER_MINUTE as i64);
     // Normalize to 0-24 hour range
-    let day_micros: i64 = 86_400_000_000;
+    let day_micros: i64 = XSD_MICROS_PER_DAY as i64;
     let normalized = ((new_local_micros % day_micros) + day_micros) % day_micros;
     XsdTime::new_with_tz(normalized as u64, new_tz_offset_minutes)
 }

--- a/xpath/src/types.nr
+++ b/xpath/src/types.nr
@@ -13,7 +13,7 @@ pub struct XsdDateTime {
     pub epoch_microseconds: Field,
     /// Timezone offset in minutes from UTC (e.g., -300 for EST, 0 for UTC)
     /// Stored as signed value: positive = east of UTC, negative = west of UTC
-    /// Range: -840 to +840 minutes (-14:00 to +14:00)
+    /// Range: `XSD_TZ_MIN_MINUTES` (-14:00) to `XSD_TZ_MAX_MINUTES` (+14:00).
     pub tz_offset_minutes: i16,
 }
 
@@ -32,7 +32,7 @@ impl XsdDateTime {
 
     /// Get the local microseconds (adjusted by timezone offset)
     pub fn local_microseconds(self) -> Field {
-        let offset_micros: i64 = (self.tz_offset_minutes as i64) * 60_000_000;
+        let offset_micros: i64 = (self.tz_offset_minutes as i64) * (TIME_MICROS_PER_MINUTE as i64);
         let utc_micros: i64 = self.epoch_microseconds as i64;
         let local: i64 = utc_micros + offset_micros;
         // Safe cast: we ensure the result is non-negative in valid use cases
@@ -102,7 +102,7 @@ pub struct XsdDate {
     /// Days since Unix epoch (1970-01-01), can be negative for dates before 1970
     pub epoch_days: i32,
     /// Timezone offset in minutes from UTC (e.g., -300 for EST, 0 for UTC)
-    /// Range: -840 to +840 minutes (-14:00 to +14:00)
+    /// Range: `XSD_TZ_MIN_MINUTES` (-14:00) to `XSD_TZ_MAX_MINUTES` (+14:00).
     pub tz_offset_minutes: i16,
 }
 
@@ -135,15 +135,18 @@ pub struct XsdTime {
     /// Microseconds since midnight (0 to 86,399,999,999)
     pub microseconds_since_midnight: u64,
     /// Timezone offset in minutes from UTC
-    /// Range: -840 to +840 minutes (-14:00 to +14:00)
+    /// Range: `XSD_TZ_MIN_MINUTES` (-14:00) to `XSD_TZ_MAX_MINUTES` (+14:00).
     pub tz_offset_minutes: i16,
 }
 
-/// Microseconds in a day constant for time calculations
-global TIME_MICROS_PER_DAY: u64 = 86_400_000_000;
-global TIME_MICROS_PER_HOUR: u64 = 3_600_000_000;
-global TIME_MICROS_PER_MINUTE: u64 = 60_000_000;
-global TIME_MICROS_PER_SECOND: u64 = 1_000_000;
+// Microsecond scaling ladder is sourced from `crate::constants` -- see
+// `xpath/src/constants.nr`. The aliases below preserve the existing
+// `TIME_MICROS_PER_*` names used by the `XsdTime` constructors below.
+use crate::constants::{
+    XSD_MICROS_PER_DAY as TIME_MICROS_PER_DAY, XSD_MICROS_PER_HOUR as TIME_MICROS_PER_HOUR,
+    XSD_MICROS_PER_MINUTE as TIME_MICROS_PER_MINUTE,
+    XSD_MICROS_PER_SECOND as TIME_MICROS_PER_SECOND,
+};
 
 impl XsdTime {
     /// Create a new Time from microseconds since midnight (assumes UTC)

--- a/xpath/src/year_month_duration.nr
+++ b/xpath/src/year_month_duration.nr
@@ -13,6 +13,7 @@
 //! XPath functions implemented:
 //! - fn:years-from-duration, fn:months-from-duration (for yearMonthDuration)
 
+use crate::constants::XSD_MONTHS_PER_YEAR;
 use crate::date::{date_from_components_with_tz, day_from_date, month_from_date, year_from_date};
 use crate::datetime::{
     datetime_from_components_with_tz, day_from_datetime, hours_from_datetime,
@@ -40,7 +41,7 @@ impl XsdYearMonthDuration {
 
     /// Create from years and months components
     pub fn from_components(negative: bool, years: u32, months: u32) -> Self {
-        let total = (years as i32) * 12 + (months as i32);
+        let total = (years as i32) * (XSD_MONTHS_PER_YEAR as i32) + (months as i32);
         let signed_total = if negative { -total } else { total };
         XsdYearMonthDuration { total_months: signed_total }
     }
@@ -85,8 +86,8 @@ pub fn fn_string_from_ym_duration<let N: u32>(dur: XsdYearMonthDuration) -> ([u8
 
     let negative = dur.total_months < 0;
     let abs_months = dur.abs_months();
-    let years = abs_months / 12;
-    let months = abs_months % 12;
+    let years = abs_months / XSD_MONTHS_PER_YEAR;
+    let months = abs_months % XSD_MONTHS_PER_YEAR;
 
     // Add '-' if negative
     if negative & (pos < N) {
@@ -247,7 +248,7 @@ pub fn ym_duration_from_string<let N: u32>(
     }
 
     // Build the result
-    let total_months = (years * 12 + months) as i32;
+    let total_months = (years * XSD_MONTHS_PER_YEAR + months) as i32;
     let signed_total = if negative {
         -total_months
     } else {
@@ -264,13 +265,13 @@ pub fn ym_duration_from_string<let N: u32>(
 /// fn:years-from-duration (for yearMonthDuration)
 /// Returns the years component (signed)
 pub fn years_from_duration(dur: XsdYearMonthDuration) -> i32 {
-    dur.total_months / 12
+    dur.total_months / (XSD_MONTHS_PER_YEAR as i32)
 }
 
 /// fn:months-from-duration (for yearMonthDuration)
 /// Returns the months component (0-11, signed based on duration sign)
 pub fn months_from_duration(dur: XsdYearMonthDuration) -> i32 {
-    dur.total_months % 12
+    dur.total_months % (XSD_MONTHS_PER_YEAR as i32)
 }
 
 // ============================================================================
@@ -392,17 +393,19 @@ pub fn datetime_add_ym_duration(dt: XsdDateTime, dur: XsdYearMonthDuration) -> X
     let tz = dt.tz_offset_minutes; // Use raw field for tz offset
 
     // Calculate new year and month
-    let total_months = (year as i32) * 12 + ((month as i32) - 1) + dur.total_months;
+    let months_per_year_i32: i32 = XSD_MONTHS_PER_YEAR as i32;
+    let total_months =
+        (year as i32) * months_per_year_i32 + ((month as i32) - 1) + dur.total_months;
 
     // Handle negative month calculations
     let new_year: i32 = if total_months >= 0 {
-        total_months / 12
+        total_months / months_per_year_i32
     } else {
         // For negative, we need floor division
-        (total_months - 11) / 12
+        (total_months - (months_per_year_i32 - 1)) / months_per_year_i32
     };
 
-    let month_rem = total_months - (new_year * 12);
+    let month_rem = total_months - (new_year * months_per_year_i32);
     let new_month = (month_rem + 1) as u8;
 
     // Clamp day to valid range for new month
@@ -436,17 +439,19 @@ pub fn date_add_ym_duration(d: XsdDate, dur: XsdYearMonthDuration) -> XsdDate {
     let tz = d.tz_offset_minutes; // Use raw field for tz offset
 
     // Calculate new year and month
-    let total_months = (year as i32) * 12 + ((month as i32) - 1) + dur.total_months;
+    let months_per_year_i32: i32 = XSD_MONTHS_PER_YEAR as i32;
+    let total_months =
+        (year as i32) * months_per_year_i32 + ((month as i32) - 1) + dur.total_months;
 
     // Handle negative month calculations
     let new_year: i32 = if total_months >= 0 {
-        total_months / 12
+        total_months / months_per_year_i32
     } else {
         // For negative, we need floor division
-        (total_months - 11) / 12
+        (total_months - (months_per_year_i32 - 1)) / months_per_year_i32
     };
 
-    let month_rem = total_months - (new_year * 12);
+    let month_rem = total_months - (new_year * months_per_year_i32);
     let new_month = (month_rem + 1) as u8;
 
     // Clamp day to valid range for new month


### PR DESCRIPTION
## Summary

Mirrors the noir_IEEE754 PR #38 phase 1+2 cleanup pattern in noir_XPath.

- **Phase 1 (commit 03c405e)**: introduce `xpath/src/constants.nr` as the single source of truth for the 4-way duplicated `MICROS_PER_*` ladder plus `XSD_MONTHS_PER_YEAR`, `XSD_TZ_{MIN,MAX}_MINUTES`, `XSD_INTEGER_I{32,64}_{MIN,MAX}`, `XSD_QNAME_MAX_*_LEN`. Per-module duplicates (`duration.nr`, `datetime.nr`, `time.nr`, `types.nr`, `qname.nr`) become `use crate::constants::* as ...` re-aliases that preserve every existing call-site name. The new globals are re-exported from `crate::lib`.
- **Phase 2a (commit 8e247cf)**: extract the qt3tests catalogue / test-set XML parser (`parse_test_file`, `discover_all_test_files`, `discover_available_functions`, `clone_or_update_qt3tests`, `TestCase`, `QT3_NS`) into a new `scripts/noir_xpath_inputs/` package, mirroring the noir_IEEE754 `noir_ieee754_inputs/` extraction.
- **Phase 2b (commit 662a010)**: add `noir_xpath_inputs/constants.py` (Python mirrors of the Noir `XSD_*` globals + small packing helpers) and rewrite the inline magic numbers in `generate_tests.py` (`86_400_000_000`, `60_000_000`, `years * 12`, `tz_mins * 60_000_000`, etc.) to use them.
- **Phase 2c (commit a4e9ecc, fix 64faa7c)**: replace the hand-rolled regex `parse_duration` / `parse_year_month_duration` with thin wrappers around `elementpath.datatypes.{DayTimeDuration,YearMonthDuration}` -- an unrelated XPath library, already a transitive dep -- so the test generator's reference path runs through CPython + an unrelated parser rather than code that resembles the Noir library under test (Concern 4 of `docs/xpath-input-prep-redesign.md`). Verified zero diffs across 1,035 dayTimeDuration + 739 yearMonthDuration literals harvested from the live qt3tests corpus.

Per-commit roborev verdicts:
- `03c405e` (phase 1): No issues found.
- `8e247cf` (phase 2a): No issues found.
- `662a010` (phase 2b): No issues found.
- `a4e9ecc` (phase 2c): One Medium finding (missing i64 guard on `parse_day_time_duration_micros`).
- `64faa7c` (fixup): No issues found. Addresses the Medium finding above by mirroring the i32 guard already present on `parse_year_month_duration_months`.

Out of scope (explicitly):
- **Codegen** is phases 3+ and blocked on D.1 / D.5 of the redesign doc.
- **Workspace `tools/` lift** of the codegen tool, the stdlib bridge, and the test-vectors loader is the cross-repo phase 0 -- a separate agent will handle that once D.1 is decided.
- **Fork-and-extract from `sissaschool/elementpath`'s `run_w3c_tests.py`** -- that file is not shipped with the installed package, so a vendored copy would have to live in the workspace `tools/noir-test-vectors/` package per redesign sec 6.3. The in-tree parser is lifted as-is here; the upstream fork happens once the workspace lift lands.

## Test plan

- [x] `nargo check --workspace` (only the pre-existing `xpath_test_fnmonths_from_duration` / `xpath_test_fnyears_from_duration` failure tracked in `STABILISATION-TODOS.md` -- not introduced by this PR).
- [x] `nargo test --package xpath_unit_tests` -- 244 / 244 passing on every commit.
- [x] `nargo fmt --check --package xpath` and `nargo fmt --check --package xpath_unit_tests` -- clean.
- [x] `python3 -c 'import generate_tests; ...'` -- imports + runs.
- [x] Cross-corpus parity: 1,035 dayTimeDuration + 739 yearMonthDuration qt3tests literals produce identical output through the new and old parsers (zero diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)