### PR TITLE
refactor(types): centralise xpath constants + import IEEE 754 masks

### DIFF
--- a/xpath/Nargo.toml
+++ b/xpath/Nargo.toml
@@ -4,5 +4,5 @@ type = "lib"
 authors = ["jeswr"]
 
 [dependencies]
-ieee754 = { tag = "v0.3.1", git = "https://github.com/jeswr/noir_IEEE754", directory = "ieee754" }
+ieee754 = { tag = "main", git = "https://github.com/jeswr/noir_IEEE754", directory = "ieee754" }
 json_parser = { tag = "main", git = "https://github.com/noir-lang/noir_json_parser" }

--- a/xpath/src/datetime.nr
+++ b/xpath/src/datetime.nr
@@ -11,16 +11,13 @@
 //! - op:dateTime-equal, op:dateTime-less-than, op:dateTime-greater-than
 
 use crate::constants::{
-    XSD_MICROS_PER_DAY as MICROSECONDS_PER_DAY, XSD_MICROS_PER_HOUR as MICROSECONDS_PER_HOUR,
-    XSD_MICROS_PER_MINUTE as MICROSECONDS_PER_MINUTE,
-    XSD_MICROS_PER_SECOND as MICROSECONDS_PER_SECOND,
+    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR, XSD_MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND,
 };
 use crate::duration::duration_from_microseconds;
 use crate::types::XsdDateTime;
 
-// Microsecond scaling ladder is sourced from `crate::constants` -- see
-// `xpath/src/constants.nr`. The local `MICROSECONDS_PER_*` aliases above
-// preserve the existing in-module names for the call sites below.
+// Microsecond scaling ladder is sourced from `crate::constants` (single
+// source of truth -- see `xpath/src/constants.nr`).
 
 // ============================================================================
 // Construction Functions
@@ -84,16 +81,16 @@ pub fn datetime_from_components_with_tz(
     let days = civil_to_days(year, month, day);
 
     // Convert time components to microseconds (local time)
-    let time_micros: u64 = (hour as u64) * MICROSECONDS_PER_HOUR
-        + (minute as u64) * MICROSECONDS_PER_MINUTE
-        + (second as u64) * MICROSECONDS_PER_SECOND
+    let time_micros: u64 = (hour as u64) * XSD_MICROS_PER_HOUR
+        + (minute as u64) * XSD_MICROS_PER_MINUTE
+        + (second as u64) * XSD_MICROS_PER_SECOND
         + microsecond as u64;
 
     // Total microseconds since epoch (in local time)
-    let local_micros: u64 = (days as u64) * MICROSECONDS_PER_DAY + time_micros;
+    let local_micros: u64 = (days as u64) * XSD_MICROS_PER_DAY + time_micros;
 
     // Convert to UTC by subtracting the timezone offset
-    let offset_micros: i64 = (tz_offset_minutes as i64) * (MICROSECONDS_PER_MINUTE as i64);
+    let offset_micros: i64 = (tz_offset_minutes as i64) * (XSD_MICROS_PER_MINUTE as i64);
     let utc_micros: i64 = (local_micros as i64) - offset_micros;
     let utc_u64: u64 = utc_micros as u64;
 
@@ -115,7 +112,7 @@ pub fn datetime_timezone_offset(dt: XsdDateTime) -> i16 {
 /// Returns the timezone offset as a duration (e.g., -PT5H for -05:00)
 pub fn timezone_from_datetime(dt: XsdDateTime) -> crate::types::XsdDayTimeDuration {
     let offset_minutes = dt.tz_offset_minutes as i64;
-    let offset_micros = offset_minutes * (MICROSECONDS_PER_MINUTE as i64);
+    let offset_micros = offset_minutes * (XSD_MICROS_PER_MINUTE as i64);
     duration_from_microseconds(offset_micros)
 }
 
@@ -152,17 +149,17 @@ pub fn day_from_datetime(dt: XsdDateTime) -> u8 {
 /// Extracts the hours component (0-23) from a dateTime value (in local time).
 pub fn hours_from_datetime(dt: XsdDateTime) -> u8 {
     let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
-    (day_micros / MICROSECONDS_PER_HOUR) as u8
+    let day_micros = micros % XSD_MICROS_PER_DAY;
+    (day_micros / XSD_MICROS_PER_HOUR) as u8
 }
 
 /// fn:minutes-from-dateTime
 /// Extracts the minutes component (0-59) from a dateTime value (in local time).
 pub fn minutes_from_datetime(dt: XsdDateTime) -> u8 {
     let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
-    let hour_micros = day_micros % MICROSECONDS_PER_HOUR;
-    (hour_micros / MICROSECONDS_PER_MINUTE) as u8
+    let day_micros = micros % XSD_MICROS_PER_DAY;
+    let hour_micros = day_micros % XSD_MICROS_PER_HOUR;
+    (hour_micros / XSD_MICROS_PER_MINUTE) as u8
 }
 
 /// fn:seconds-from-dateTime (integer part only)
@@ -171,16 +168,16 @@ pub fn minutes_from_datetime(dt: XsdDateTime) -> u8 {
 /// use microseconds_from_datetime for the fractional part.
 pub fn seconds_from_datetime(dt: XsdDateTime) -> u8 {
     let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
-    let hour_micros = day_micros % MICROSECONDS_PER_HOUR;
-    let minute_micros = hour_micros % MICROSECONDS_PER_MINUTE;
-    (minute_micros / MICROSECONDS_PER_SECOND) as u8
+    let day_micros = micros % XSD_MICROS_PER_DAY;
+    let hour_micros = day_micros % XSD_MICROS_PER_HOUR;
+    let minute_micros = hour_micros % XSD_MICROS_PER_MINUTE;
+    (minute_micros / XSD_MICROS_PER_SECOND) as u8
 }
 
 /// Extract microseconds within the current second (0-999999)
 pub fn microseconds_from_datetime(dt: XsdDateTime) -> u32 {
     let micros: u64 = dt.local_microseconds() as u64;
-    (micros % MICROSECONDS_PER_SECOND) as u32
+    (micros % XSD_MICROS_PER_SECOND) as u32
 }
 
 // ============================================================================
@@ -263,7 +260,7 @@ fn civil_to_days(year: i32, month: u8, day: u8) -> i64 {
 fn epoch_to_civil(epoch_micros: Field) -> (i32, u8, u8) {
     // Convert to days since epoch
     let micros: u64 = epoch_micros as u64;
-    let days: i64 = (micros / MICROSECONDS_PER_DAY) as i64;
+    let days: i64 = (micros / XSD_MICROS_PER_DAY) as i64;
 
     // Shift epoch from 1970-01-01 to 0000-03-01 for easier leap year handling
     // days from 1970-01-01 to 0000-03-01 is -719468

--- a/xpath/src/duration.nr
+++ b/xpath/src/duration.nr
@@ -14,24 +14,9 @@ use crate::constants::{
 };
 use crate::types::{XsdDateTime, XsdDayTimeDuration};
 
-// ============================================================================
-// Time Constants (signed-i64 aliases of the canonical u64 constants in
-// `crate::constants`. Sign-extending the u64 globals at compile time
-// keeps the duration arithmetic below in i64 without re-declaring the
-// magic numbers.)
-// ============================================================================
-
-/// Microseconds per second.
-global MICROS_PER_SECOND: i64 = XSD_MICROS_PER_SECOND as i64;
-
-/// Microseconds per minute.
-global MICROS_PER_MINUTE: i64 = XSD_MICROS_PER_MINUTE as i64;
-
-/// Microseconds per hour.
-global MICROS_PER_HOUR: i64 = XSD_MICROS_PER_HOUR as i64;
-
-/// Microseconds per day.
-global MICROS_PER_DAY: i64 = XSD_MICROS_PER_DAY as i64;
+// Microsecond scaling ladder is sourced from `crate::constants` (single
+// source of truth -- see `xpath/src/constants.nr`). Call sites cast the
+// canonical u64 globals to i64 inline to keep duration arithmetic signed.
 
 // ============================================================================
 // Duration Construction Functions
@@ -52,10 +37,10 @@ pub fn duration_from_components(
     seconds: u32,
     microseconds: u32,
 ) -> XsdDayTimeDuration {
-    let total: i64 = (days as i64) * MICROS_PER_DAY
-        + (hours as i64) * MICROS_PER_HOUR
-        + (minutes as i64) * MICROS_PER_MINUTE
-        + (seconds as i64) * MICROS_PER_SECOND
+    let total: i64 = (days as i64) * (XSD_MICROS_PER_DAY as i64)
+        + (hours as i64) * (XSD_MICROS_PER_HOUR as i64)
+        + (minutes as i64) * (XSD_MICROS_PER_MINUTE as i64)
+        + (seconds as i64) * (XSD_MICROS_PER_SECOND as i64)
         + microseconds as i64;
 
     let signed_total = if negative { -total } else { total };
@@ -85,31 +70,31 @@ pub fn duration_is_negative(dur: XsdDayTimeDuration) -> bool {
 pub fn days_from_duration(dur: XsdDayTimeDuration) -> u32 {
     let micros = dur.to_signed_micros();
     let abs_micros: i64 = if micros < 0 { -micros } else { micros };
-    (abs_micros / MICROS_PER_DAY) as u32
+    (abs_micros / (XSD_MICROS_PER_DAY as i64)) as u32
 }
 
 /// Extract hours component (0-23, absolute value)
 pub fn hours_from_duration(dur: XsdDayTimeDuration) -> u8 {
     let micros = dur.to_signed_micros();
     let abs_micros: i64 = if micros < 0 { -micros } else { micros };
-    let day_remainder = abs_micros % MICROS_PER_DAY;
-    (day_remainder / MICROS_PER_HOUR) as u8
+    let day_remainder = abs_micros % (XSD_MICROS_PER_DAY as i64);
+    (day_remainder / (XSD_MICROS_PER_HOUR as i64)) as u8
 }
 
 /// Extract minutes component (0-59, absolute value)
 pub fn minutes_from_duration(dur: XsdDayTimeDuration) -> u8 {
     let micros = dur.to_signed_micros();
     let abs_micros: i64 = if micros < 0 { -micros } else { micros };
-    let hour_remainder = abs_micros % MICROS_PER_HOUR;
-    (hour_remainder / MICROS_PER_MINUTE) as u8
+    let hour_remainder = abs_micros % (XSD_MICROS_PER_HOUR as i64);
+    (hour_remainder / (XSD_MICROS_PER_MINUTE as i64)) as u8
 }
 
 /// Extract seconds component (0-59, absolute value)
 pub fn seconds_from_duration(dur: XsdDayTimeDuration) -> u8 {
     let micros = dur.to_signed_micros();
     let abs_micros: i64 = if micros < 0 { -micros } else { micros };
-    let minute_remainder = abs_micros % MICROS_PER_MINUTE;
-    (minute_remainder / MICROS_PER_SECOND) as u8
+    let minute_remainder = abs_micros % (XSD_MICROS_PER_MINUTE as i64);
+    (minute_remainder / (XSD_MICROS_PER_SECOND as i64)) as u8
 }
 
 // ============================================================================
@@ -288,7 +273,7 @@ fn test_datetime_duration_arithmetic() {
 #[test]
 fn test_datetime_difference() {
     let dt1 = XsdDateTime::new(0);
-    let dt2_micros: Field = 86_400_000_000; // 1 day in microseconds
+    let dt2_micros: Field = XSD_MICROS_PER_DAY as Field; // 1 day in microseconds
     let dt2 = XsdDateTime::new(dt2_micros);
 
     let diff = datetime_difference(dt2, dt1);

--- a/xpath/src/numeric_types.nr
+++ b/xpath/src/numeric_types.nr
@@ -26,7 +26,9 @@ use ieee754::float::{
     sub_float64,
 };
 use ieee754::types::{
-    ROUNDING_MODE_NEAREST_AWAY, ROUNDING_MODE_TOWARD_NEGATIVE, ROUNDING_MODE_TOWARD_POSITIVE,
+    FLOAT32_EXPONENT_MASK, FLOAT32_MANTISSA_MASK, FLOAT32_SIGN_MASK, FLOAT64_EXPONENT_MASK,
+    FLOAT64_MANTISSA_MASK, FLOAT64_SIGN_MASK, ROUNDING_MODE_NEAREST_AWAY,
+    ROUNDING_MODE_TOWARD_NEGATIVE, ROUNDING_MODE_TOWARD_POSITIVE,
 };
 
 // ============================================================================
@@ -926,17 +928,14 @@ pub fn cast_double_to_float(d: XsdDouble) -> XsdFloat {
 // Rounding Functions
 // ============================================================================
 
-// Float32 constants
-global FLOAT32_SIGN_MASK: u32 = 0x80000000;
-global FLOAT32_EXP_MASK: u32 = 0x7F800000;
-global FLOAT32_MANTISSA_MASK: u32 = 0x007FFFFF;
+// Float32 / Float64 layout constants.
+// `FLOAT{32,64}_SIGN_MASK`, `FLOAT{32,64}_EXPONENT_MASK` and
+// `FLOAT{32,64}_MANTISSA_MASK` are imported above from `ieee754::types`
+// (single source of truth -- see `noir_IEEE754/ieee754/src/types.nr`).
+// `EXP_BIAS` and `MANTISSA_BITS` are not yet exported by noir_IEEE754;
+// they remain local until the IEEE 754 crate publishes them.
 global FLOAT32_EXP_BIAS: u32 = 127;
 global FLOAT32_MANTISSA_BITS: u32 = 23;
-
-// Float64 constants
-global FLOAT64_SIGN_MASK: u64 = 0x8000000000000000;
-global FLOAT64_EXP_MASK: u64 = 0x7FF0000000000000;
-global FLOAT64_MANTISSA_MASK: u64 = 0x000FFFFFFFFFFFFF;
 global FLOAT64_EXP_BIAS: u64 = 1023;
 global FLOAT64_MANTISSA_BITS: u64 = 52;
 
@@ -950,7 +949,7 @@ pub fn round_float(a: XsdFloat) -> XsdFloat {
 
     let sign = bits & FLOAT32_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT32_EXP_MASK) >> FLOAT32_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT32_EXPONENT_MASK) >> FLOAT32_MANTISSA_BITS;
     let mantissa = bits & FLOAT32_MANTISSA_MASK;
     let exp = exp_bits as i32 - FLOAT32_EXP_BIAS as i32;
 
@@ -1045,7 +1044,7 @@ pub fn round_double(a: XsdDouble) -> XsdDouble {
 
     let sign = bits & FLOAT64_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT64_EXP_MASK) >> FLOAT64_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT64_EXPONENT_MASK) >> FLOAT64_MANTISSA_BITS;
     let mantissa = bits & FLOAT64_MANTISSA_MASK;
     let exp = exp_bits as i64 - FLOAT64_EXP_BIAS as i64;
 
@@ -1135,7 +1134,7 @@ pub fn ceil_float(a: XsdFloat) -> XsdFloat {
 
     let sign = bits & FLOAT32_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT32_EXP_MASK) >> FLOAT32_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT32_EXPONENT_MASK) >> FLOAT32_MANTISSA_BITS;
     let mantissa = bits & FLOAT32_MANTISSA_MASK;
     let exp = exp_bits as i32 - FLOAT32_EXP_BIAS as i32;
 
@@ -1203,7 +1202,7 @@ pub fn ceil_double(a: XsdDouble) -> XsdDouble {
 
     let sign = bits & FLOAT64_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT64_EXP_MASK) >> FLOAT64_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT64_EXPONENT_MASK) >> FLOAT64_MANTISSA_BITS;
     let mantissa = bits & FLOAT64_MANTISSA_MASK;
     let exp = exp_bits as i64 - FLOAT64_EXP_BIAS as i64;
 
@@ -1271,7 +1270,7 @@ pub fn floor_float(a: XsdFloat) -> XsdFloat {
 
     let sign = bits & FLOAT32_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT32_EXP_MASK) >> FLOAT32_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT32_EXPONENT_MASK) >> FLOAT32_MANTISSA_BITS;
     let mantissa = bits & FLOAT32_MANTISSA_MASK;
     let exp = exp_bits as i32 - FLOAT32_EXP_BIAS as i32;
 
@@ -1339,7 +1338,7 @@ pub fn floor_double(a: XsdDouble) -> XsdDouble {
 
     let sign = bits & FLOAT64_SIGN_MASK;
     let is_negative = sign != 0;
-    let exp_bits = (bits & FLOAT64_EXP_MASK) >> FLOAT64_MANTISSA_BITS;
+    let exp_bits = (bits & FLOAT64_EXPONENT_MASK) >> FLOAT64_MANTISSA_BITS;
     let mantissa = bits & FLOAT64_MANTISSA_MASK;
     let exp = exp_bits as i64 - FLOAT64_EXP_BIAS as i64;
 

--- a/xpath/src/qname.nr
+++ b/xpath/src/qname.nr
@@ -10,12 +10,9 @@
 // QName Type
 // ============================================================================
 
-// QName component buffer sizes are sourced from `crate::constants` --
-// see `xpath/src/constants.nr`. The aliases below preserve the existing
-// in-module names for the call sites below.
-use crate::constants::{
-    XSD_QNAME_MAX_LOCAL_LEN as MAX_LOCALNAME_LEN, XSD_QNAME_MAX_NS_LEN as MAX_NAMESPACE_LEN,
-};
+// QName component buffer sizes are sourced from `crate::constants` (single
+// source of truth -- see `xpath/src/constants.nr`). They are referenced by
+// the test generator and downstream consumers via `xpath::XSD_QNAME_MAX_*`.
 
 /// XSD QName representation
 /// A qualified name consists of a namespace URI and a local name

--- a/xpath/src/time.nr
+++ b/xpath/src/time.nr
@@ -9,14 +9,12 @@
 //! - op:time-equal, op:time-less-than, op:time-greater-than
 
 use crate::constants::{
-    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR as MICROS_PER_HOUR,
-    XSD_MICROS_PER_MINUTE as MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND as MICROS_PER_SECOND,
+    XSD_MICROS_PER_DAY, XSD_MICROS_PER_HOUR, XSD_MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND,
 };
 use crate::types::{XsdDayTimeDuration, XsdTime};
 
-// Microsecond scaling ladder is sourced from `crate::constants` -- see
-// `xpath/src/constants.nr`. The local `MICROS_PER_*` aliases above
-// preserve the existing in-module names for the call sites below.
+// Microsecond scaling ladder is sourced from `crate::constants` (single
+// source of truth -- see `xpath/src/constants.nr`).
 
 // ============================================================================
 // Time Construction Functions
@@ -64,29 +62,29 @@ pub fn time_from_microseconds_with_tz(micros: u64, tz_offset_minutes: i16) -> Xs
 
 /// fn:hours-from-time - Extract hours component (0-23)
 pub fn hours_from_time(time: XsdTime) -> u8 {
-    (time.microseconds_since_midnight / MICROS_PER_HOUR) as u8
+    (time.microseconds_since_midnight / XSD_MICROS_PER_HOUR) as u8
 }
 
 /// fn:minutes-from-time - Extract minutes component (0-59)
 pub fn minutes_from_time(time: XsdTime) -> u8 {
-    let hour_remainder = time.microseconds_since_midnight % MICROS_PER_HOUR;
-    (hour_remainder / MICROS_PER_MINUTE) as u8
+    let hour_remainder = time.microseconds_since_midnight % XSD_MICROS_PER_HOUR;
+    (hour_remainder / XSD_MICROS_PER_MINUTE) as u8
 }
 
 /// fn:seconds-from-time - Extract seconds component (0-59)
 pub fn seconds_from_time(time: XsdTime) -> u8 {
-    let minute_remainder = time.microseconds_since_midnight % MICROS_PER_MINUTE;
-    (minute_remainder / MICROS_PER_SECOND) as u8
+    let minute_remainder = time.microseconds_since_midnight % XSD_MICROS_PER_MINUTE;
+    (minute_remainder / XSD_MICROS_PER_SECOND) as u8
 }
 
 /// Extract microseconds within the current second (0-999999)
 pub fn microseconds_from_time(time: XsdTime) -> u32 {
-    (time.microseconds_since_midnight % MICROS_PER_SECOND) as u32
+    (time.microseconds_since_midnight % XSD_MICROS_PER_SECOND) as u32
 }
 
 /// fn:timezone-from-time - Extract timezone as a dayTimeDuration
 pub fn timezone_from_time(time: XsdTime) -> XsdDayTimeDuration {
-    let offset_micros: i64 = (time.tz_offset_minutes as i64) * (MICROS_PER_MINUTE as i64);
+    let offset_micros: i64 = (time.tz_offset_minutes as i64) * (XSD_MICROS_PER_MINUTE as i64);
     XsdDayTimeDuration::from_signed_micros(offset_micros)
 }
 
@@ -167,7 +165,7 @@ pub fn adjust_time_to_timezone(time: XsdTime, new_tz_offset_minutes: i16) -> Xsd
     let utc_micros = time.utc_microseconds();
     // Create a new time with the new timezone, adjusting for the offset difference
     let offset_diff = new_tz_offset_minutes as i64 - time.tz_offset_minutes as i64;
-    let new_local_micros = utc_micros + offset_diff * (MICROS_PER_MINUTE as i64);
+    let new_local_micros = utc_micros + offset_diff * (XSD_MICROS_PER_MINUTE as i64);
     // Normalize to 0-24 hour range
     let day_micros: i64 = XSD_MICROS_PER_DAY as i64;
     let normalized = ((new_local_micros % day_micros) + day_micros) % day_micros;

--- a/xpath/src/types.nr
+++ b/xpath/src/types.nr
@@ -32,7 +32,7 @@ impl XsdDateTime {
 
     /// Get the local microseconds (adjusted by timezone offset)
     pub fn local_microseconds(self) -> Field {
-        let offset_micros: i64 = (self.tz_offset_minutes as i64) * (TIME_MICROS_PER_MINUTE as i64);
+        let offset_micros: i64 = (self.tz_offset_minutes as i64) * (XSD_MICROS_PER_MINUTE as i64);
         let utc_micros: i64 = self.epoch_microseconds as i64;
         let local: i64 = utc_micros + offset_micros;
         // Safe cast: we ensure the result is non-negative in valid use cases
@@ -139,14 +139,9 @@ pub struct XsdTime {
     pub tz_offset_minutes: i16,
 }
 
-// Microsecond scaling ladder is sourced from `crate::constants` -- see
-// `xpath/src/constants.nr`. The aliases below preserve the existing
-// `TIME_MICROS_PER_*` names used by the `XsdTime` constructors below.
-use crate::constants::{
-    XSD_MICROS_PER_DAY as TIME_MICROS_PER_DAY, XSD_MICROS_PER_HOUR as TIME_MICROS_PER_HOUR,
-    XSD_MICROS_PER_MINUTE as TIME_MICROS_PER_MINUTE,
-    XSD_MICROS_PER_SECOND as TIME_MICROS_PER_SECOND,
-};
+// Microsecond scaling ladder is sourced from `crate::constants` (single
+// source of truth -- see `xpath/src/constants.nr`).
+use crate::constants::{XSD_MICROS_PER_HOUR, XSD_MICROS_PER_MINUTE, XSD_MICROS_PER_SECOND};
 
 impl XsdTime {
     /// Create a new Time from microseconds since midnight (assumes UTC)
@@ -161,9 +156,9 @@ impl XsdTime {
 
     /// Create a Time from components
     pub fn from_components(hours: u8, minutes: u8, seconds: u8, microseconds: u32) -> Self {
-        let micros = (hours as u64) * TIME_MICROS_PER_HOUR
-            + (minutes as u64) * TIME_MICROS_PER_MINUTE
-            + (seconds as u64) * TIME_MICROS_PER_SECOND
+        let micros = (hours as u64) * XSD_MICROS_PER_HOUR
+            + (minutes as u64) * XSD_MICROS_PER_MINUTE
+            + (seconds as u64) * XSD_MICROS_PER_SECOND
             + microseconds as u64;
         XsdTime::new(micros)
     }
@@ -176,9 +171,9 @@ impl XsdTime {
         microseconds: u32,
         tz_offset_minutes: i16,
     ) -> Self {
-        let micros = (hours as u64) * TIME_MICROS_PER_HOUR
-            + (minutes as u64) * TIME_MICROS_PER_MINUTE
-            + (seconds as u64) * TIME_MICROS_PER_SECOND
+        let micros = (hours as u64) * XSD_MICROS_PER_HOUR
+            + (minutes as u64) * XSD_MICROS_PER_MINUTE
+            + (seconds as u64) * XSD_MICROS_PER_SECOND
             + microseconds as u64;
         XsdTime::new_with_tz(micros, tz_offset_minutes)
     }
@@ -187,7 +182,7 @@ impl XsdTime {
     /// Normalizes to UTC by subtracting the timezone offset
     pub fn utc_microseconds(self) -> i64 {
         let local_micros = self.microseconds_since_midnight as i64;
-        let offset_micros = (self.tz_offset_minutes as i64) * 60_000_000;
+        let offset_micros = (self.tz_offset_minutes as i64) * (XSD_MICROS_PER_MINUTE as i64);
         local_micros - offset_micros
     }
 }


### PR DESCRIPTION
## Summary

Lands the two related decisions from `questions/xpath-constants-consolidation.md` (DECIDED option A, centralise) and `questions/xpath-ieee754-mask-reuse.md` (DECIDED option A, import from IEEE 754) as one PR.

- **Commit 1 -- `refactor(types): centralise xpath constants in xpath/src/constants.nr`**
  Drops the per-module renamed aliases (`MICROS_PER_*`, `MICROSECONDS_PER_*`, `TIME_MICROS_PER_*`, `MAX_NAMESPACE_LEN`, `MAX_LOCALNAME_LEN`) and the local i64 sign-extended `global MICROS_PER_*` declarations in `duration.nr`. Every `xpath/src/*.nr` that touches XSD constants now imports the canonical `XSD_*` names directly from `crate::constants`. Two inline magic numbers (`60_000_000` and `86_400_000_000`) replaced with the canonical constants.

- **Commit 2 -- `refactor(types): import IEEE 754 masks from noir_IEEE754 instead of redefining them`**
  Drops the local `FLOAT{32,64}_SIGN_MASK` / `FLOAT{32,64}_EXP_MASK` / `FLOAT{32,64}_MANTISSA_MASK` `pub global` declarations in `numeric_types.nr` and imports the canonical masks from `ieee754::types`. Local call sites renamed `FLOAT*_EXP_MASK` -> `FLOAT*_EXPONENT_MASK` (matching upstream). `EXP_BIAS` and `MANTISSA_BITS` stay local because noir_IEEE754 doesn't yet export them.

Both commits reviewed by `roborev review --agent codex --model gpt-5.5`:
- Commit 1: **No issues found**.
- Commit 2: Medium-severity flag for `tag = "main"` pin (non-reproducible). Documented as a follow-up: noir_IEEE754 needs a release tag covering commit `82de693` (`feat(types): add IEEE 754 mask + min/max constants`); Nargo's `tag` field clones with `git clone --depth 1 --branch <ref>` and so doesn't accept raw SHAs.

## Test plan

- [x] `nargo check --workspace` -- green
- [x] `nargo test --package xpath` -- 81/81 passing
- [x] `nargo test --workspace` -- xpath_unit_tests 244/244 passing
- [x] `roborev review` on each commit

## Follow-ups

- Cut a release tag on `noir_IEEE754` covering commit `82de693fe51bfc7b2bb159f7ff6328599d010f9a` (mask constants) and re-pin `xpath/Nargo.toml` from `tag = "main"` to that tag for reproducible builds.
- When `noir_IEEE754` exports `FLOAT*_EXP_BIAS` and `FLOAT*_MANTISSA_BITS`, drop the remaining local copies in `numeric_types.nr`.
