### PR TITLE
ci: require Copilot review before merge

### DIFF
--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -21,6 +21,7 @@ name: Require Copilot review
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, reopened, ready_for_review, synchronize]
   pull_request_review:
     types: [submitted, edited, dismissed]
@@ -32,23 +33,21 @@ permissions:
 jobs:
   copilot-review-posted:
     name: copilot-review-posted
+    # Skip pull_request_review events targeting non-default branches; the
+    # `pull_request_review` trigger does not honour the `branches:` filter
+    # above, so we gate it explicitly here.
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number
         id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "number=${{ github.event.pull_request.number }}" >>"$GITHUB_OUTPUT"
-            echo "author=${{ github.event.pull_request.user.login }}" >>"$GITHUB_OUTPUT"
-            echo "draft=${{ github.event.pull_request.draft }}" >>"$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.pull_request.number }}" >>"$GITHUB_OUTPUT"
-            echo "author=${{ github.event.pull_request.user.login }}" >>"$GITHUB_OUTPUT"
-            echo "draft=${{ github.event.pull_request.draft }}" >>"$GITHUB_OUTPUT"
-          fi
+          echo "number=${{ github.event.pull_request.number }}" >>"$GITHUB_OUTPUT"
+          echo "author=${{ github.event.pull_request.user.login }}" >>"$GITHUB_OUTPUT"
+          echo "draft=${{ github.event.pull_request.draft }}" >>"$GITHUB_OUTPUT"
 
       - name: Exempt automated / draft PRs
         id: exempt
@@ -85,9 +84,12 @@ jobs:
           # The review-summary endpoint reports the bot as
           # `copilot-pull-request-reviewer[bot]`; the review-line-comments
           # endpoint reports `Copilot` (same identity, different surface).
-          # We check `/reviews` which uses the bot login.
-          reviewers=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+          # We check `/reviews` which uses the bot login. `--paginate` walks
+          # every page so the gate cannot false-fail when a PR accumulates
+          # >30 reviews (default page size).
+          reviewers=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length' \
+            | awk '{s+=$1} END {print s+0}')
           if [[ "$reviewers" -ge 1 ]]; then
             echo "::notice::Copilot has posted $reviewers review(s) on PR #$PR_NUMBER."
             exit 0

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -22,7 +22,17 @@ name: Require Copilot review
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, ready_for_review, synchronize]
+    # `edited` covers PR retarget from another base to `main` (which fires
+    # `pull_request.edited`, not `opened`/`reopened`); `converted_to_draft`
+    # lets the draft exemption take effect when a PR is moved back to
+    # draft after the check has already failed.
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - edited
+      - converted_to_draft
   pull_request_review:
     types: [submitted, edited, dismissed]
 
@@ -40,6 +50,9 @@ jobs:
       github.event_name == 'pull_request' ||
       github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
+    # Fail fast if the GitHub API call hangs — every other workflow in the
+    # repo sets a timeout, and a stuck merge gate is the worst kind of red.
+    timeout-minutes: 5
     steps:
       - name: Resolve PR number
         id: pr
@@ -86,9 +99,11 @@ jobs:
           # endpoint reports `Copilot` (same identity, different surface).
           # We check `/reviews` which uses the bot login. `--paginate` walks
           # every page so the gate cannot false-fail when a PR accumulates
-          # >30 reviews (default page size).
+          # >30 reviews (default page size). DISMISSED reviews are
+          # filtered out so dismissing Copilot's only review re-reds the
+          # gate (matches the policy in the deployment notes).
           reviewers=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length' \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | select(.state != "DISMISSED")] | length' \
             | awk '{s+=$1} END {print s+0}')
           if [[ "$reviewers" -ge 1 ]]; then
             echo "::notice::Copilot has posted $reviewers review(s) on PR #$PR_NUMBER."

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -1,0 +1,99 @@
+name: Require Copilot review
+
+# Gate: merge to `main` is blocked until `copilot-pull-request-reviewer[bot]`
+# has posted at least one review on the PR. This workflow exposes a required
+# status check (`copilot-review-posted`) consumed by the repo ruleset on
+# `~DEFAULT_BRANCH`.
+#
+# Rationale: per `notes/research/pr-review-audit-2026-05-03.md`, 15 of 56
+# merged-with-review PRs across the three sub-repos were merged BEFORE
+# Copilot's first review timestamp. This workflow closes that gap. It does
+# *not* enforce thread resolution — only that a review has been posted.
+#
+# Exemptions (the check passes without a review):
+#   - Author is `dependabot[bot]` — Copilot does not review dep bumps.
+#   - Author is `Copilot` (the coding agent) — Copilot does not review its
+#     own PRs.
+#   - PR is draft — Copilot only reviews ready-for-review PRs.
+#
+# This file is managed by `scripts/sync-standards.sh`. Edit the canonical at
+# `templates/sub-repo/noir/.github/workflows/require-copilot-review.yml`.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  copilot-review-posted:
+    name: copilot-review-posted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "number=${{ github.event.pull_request.number }}" >>"$GITHUB_OUTPUT"
+            echo "author=${{ github.event.pull_request.user.login }}" >>"$GITHUB_OUTPUT"
+            echo "draft=${{ github.event.pull_request.draft }}" >>"$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >>"$GITHUB_OUTPUT"
+            echo "author=${{ github.event.pull_request.user.login }}" >>"$GITHUB_OUTPUT"
+            echo "draft=${{ github.event.pull_request.draft }}" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Exempt automated / draft PRs
+        id: exempt
+        run: |
+          set -euo pipefail
+          author='${{ steps.pr.outputs.author }}'
+          draft='${{ steps.pr.outputs.draft }}'
+          if [[ "$author" == "dependabot[bot]" ]]; then
+            echo "reason=dependabot author — Copilot does not review dep bumps" >>"$GITHUB_OUTPUT"
+            echo "exempt=true" >>"$GITHUB_OUTPUT"
+          elif [[ "$author" == "Copilot" ]] || [[ "$author" == "copilot-swe-agent[bot]" ]]; then
+            echo "reason=Copilot-authored PR — Copilot does not review itself" >>"$GITHUB_OUTPUT"
+            echo "exempt=true" >>"$GITHUB_OUTPUT"
+          elif [[ "$draft" == "true" ]]; then
+            echo "reason=draft PR — Copilot reviews ready-for-review PRs only" >>"$GITHUB_OUTPUT"
+            echo "exempt=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "exempt=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip — exempt
+        if: steps.exempt.outputs.exempt == 'true'
+        run: |
+          echo "::notice::Exempt: ${{ steps.exempt.outputs.reason }}"
+
+      - name: Check that Copilot has posted a review
+        if: steps.exempt.outputs.exempt != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The review-summary endpoint reports the bot as
+          # `copilot-pull-request-reviewer[bot]`; the review-line-comments
+          # endpoint reports `Copilot` (same identity, different surface).
+          # We check `/reviews` which uses the bot login.
+          reviewers=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+          if [[ "$reviewers" -ge 1 ]]; then
+            echo "::notice::Copilot has posted $reviewers review(s) on PR #$PR_NUMBER."
+            exit 0
+          fi
+          echo "::error::No review from copilot-pull-request-reviewer[bot] yet on PR #$PR_NUMBER."
+          echo "If Copilot review has not been requested, request one. The check"
+          echo "re-runs on each pull_request_review event, so it will turn green"
+          echo "once Copilot posts."
+          exit 1

--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -6,6 +6,7 @@
     ".github/noir-versions.json": "8bfc115aa4ad34f8e7715a4df76ccca454248a54b662a218795a7ea903348a45",
     ".github/workflows/release.yml": "94ab10aa361839291eafaf2f2e86f425494beabb9683a67e3e236169091c6cf7",
     ".github/workflows/gate-count-pr.yml": "32c11e0969445de00eb0844d199e0401a2715e66b023dbfc73da7ef5dd5f0a6b",
+    ".github/workflows/require-copilot-review.yml": "ff5276beaffdba3996413d1ce1c850a6793095147b7fa80aadcc66580ba97c55",
     ".github/workflows/automerge.yml": "548ba3f7178aed11fb297da363dc2ce775126fd88d7de4e05deff94760fc1b50",
     ".github/workflows/check-noir-version.yml": "db0648fc41095f02590deb6015f1b579bef23d9339ddbf42ac498bd5527c8e3c",
     ".github/workflows/ci.yml": "7f4512c3bd4549acbc744fa658953bd60a6ee68f30bd63a4cb8c5ea9977eb164",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/require-copilot-review.yml`, exposing a `copilot-review-posted` status check that fails until `copilot-pull-request-reviewer[bot]` has posted a review on the PR.
- Re-runs on `pull_request_review` events so it flips green automatically once Copilot posts.
- Exempts dependabot, Copilot-authored, and draft PRs.
- Closes the merge-before-review gap surfaced in `notes/research/pr-review-audit-2026-05-03.md`.

## Ruleset side (applied via API, not committed here)
After this PR merges, the existing "Copilot review for default branch" ruleset (id `11240397`) will be augmented with a `pull_request` rule + a `required_status_checks` rule referencing `copilot-review-posted`. See `notes/research/copilot-merge-gate-deployment-2026-05-03.md` in the workspace.

## Test plan
- [ ] Land sparql_noir's parallel PR (#45) first to validate the gate end-to-end.
- [ ] Merge this PR.
- [ ] Apply ruleset update via `gh api -X PUT repos/jeswr/noir_XPath/rulesets/11240397`.
- [ ] Verify on the next non-dependabot, non-Copilot, non-draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)