### PR TITLE
ci: use xpath package names so main goes green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,15 @@
-# Canonical CI workflow template for Noir-flavoured sub-repos.
+# CI workflow for noir_XPath.
 #
-# Source of truth: zkp-sparql-workspace/templates/sub-repo/noir/.github/workflows/ci.yml.tmpl
-# Rendered by:    zkp-sparql-workspace/scripts/sync-standards.sh
-#
-# Hook blocks delimited by `# HOOK:<name>` / `# /HOOK:<name>` are kept when
-# `<name>` appears in this sub-repo's `ci_hooks` list in `.sync.json`, and
-# stripped otherwise. Variables `${PACKAGE_NAME}` etc. are NOT yet supported —
-# this template is lifted verbatim from `noir_IEEE754` (canonical per §3 of
-# `docs/cross-repo-consistency-plan.md`), so package names currently read
-# `ieee754`. Phase 2 of the migration plan introduces per-repo variable
-# substitution; until then, only `noir_IEEE754` should be rendered from this
-# template.
+# NOTE: this file is rendered from
+# `zkp-sparql-workspace/templates/sub-repo/noir/.github/workflows/ci.yml.tmpl`
+# but currently carries local edits to use this repo's package names
+# (`xpath` / `xpath_unit_tests`) rather than the canonical's hard-coded
+# `ieee754` / `ieee754_unit_tests`. The next phase of the cross-repo
+# consistency plan introduces `${PACKAGE_NAME}` / `${UNIT_TEST_PACKAGE}`
+# substitution in the renderer; once that lands, re-running
+# `scripts/sync-standards.sh` will reproduce these edits from the canonical
+# without manual intervention. Tracked in
+# zkp-sparql-workspace `STABILISATION-TODOS.md` (Template-substitution gaps).
 name: CI
 
 on:
@@ -59,7 +58,7 @@ jobs:
           toolchain: ${{ matrix.noir-version }}
 
       - name: Check format
-        run: nargo fmt --check --package ieee754
+        run: nargo fmt --check --package xpath
 
   # Run unit tests on all Noir versions
   unit-tests:
@@ -82,8 +81,7 @@ jobs:
       - name: Run unit tests
         run: |
           echo "Running unit tests"
-          nargo test --package ieee754_unit_tests test_float32 || exit 1
-          nargo test --package ieee754_unit_tests test_float64 || exit 1
+          nargo test --package xpath_unit_tests || exit 1
 
 
   # Summary job that depends on all test jobs

--- a/xpath/Nargo.toml
+++ b/xpath/Nargo.toml
@@ -5,4 +5,4 @@ authors = ["jeswr"]
 
 [dependencies]
 ieee754 = { tag = "main", git = "https://github.com/jeswr/noir_IEEE754", directory = "ieee754" }
-json_parser = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_json_parser" }
+json_parser = { tag = "main", git = "https://github.com/noir-lang/noir_json_parser" }

--- a/xpath/Nargo.toml
+++ b/xpath/Nargo.toml
@@ -5,4 +5,4 @@ authors = ["jeswr"]
 
 [dependencies]
 ieee754 = { tag = "main", git = "https://github.com/jeswr/noir_IEEE754", directory = "ieee754" }
-json_parser = { tag = "main", git = "https://github.com/noir-lang/noir_json_parser" }
+json_parser = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_json_parser" }


### PR DESCRIPTION
## Summary

CI on `main` has been red since the canonical `ci.yml.tmpl` was propagated
in PR #30, because the canonical hard-codes `--package ieee754` /
`--package ieee754_unit_tests`. Every `lint` and `unit-tests` job has been
exiting with `Selected package 'ieee754' was not found`.

This PR diverges the rendered `ci.yml` from the canonical to use this
repo's actual package names (`xpath` / `xpath_unit_tests`). The header
comment notes the divergence. Once the workspace renderer learns
`${PACKAGE_NAME}` substitution (tracked in
zkp-sparql-workspace `STABILISATION-TODOS.md` "Template-substitution gaps"),
re-running `scripts/sync-standards.sh` will reproduce these edits from the
canonical without manual intervention.

Also drops the `test_float32` / `test_float64` test-name filter from the
unit-tests step — `xpath_unit_tests` has no tests matching those prefixes
(modules are `numeric_tests`, `date_tests`, `comparison_tests`, etc.), so
the filter would silently run zero tests.

## Test plan

- [ ] `lint` passes against `xpath` package on every Noir version in the
      matrix.
- [ ] `unit-tests` runs the full `xpath_unit_tests` suite on every Noir
      version in the matrix.
- [ ] CI on `main` flips green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)