### PR TITLE
sync(xpath): signed-epoch + floor-div from sparq PR #1523 (sq-zqtd3)

### DIFF
--- a/xpath/src/date.nr
+++ b/xpath/src/date.nr
@@ -276,23 +276,36 @@ fn test_date_roundtrip_various_samples() {
 // Date + Duration Arithmetic
 // ============================================================================
 
-/// op:add-dayTimeDuration-to-date
-/// Adds a dayTimeDuration to a date, returning a new date
+/// op:add-dayTimeDuration-to-date -- XPath F&O 3.1 (9.7.2)
+///
+/// F&O defines this as: cast $arg1 to an xs:dateTime with time 00:00:00, add the
+/// dayTimeDuration, then cast the result back to xs:date. Casting a dateTime back
+/// to a date takes its date component, i.e. FLOORS the instant to the whole day.
+/// So a sub-day / negative duration that crosses midnight must shift the calendar
+/// day (e.g. 1970-01-01 + (-PT1H) = 1969-12-31). Noir integer `/` truncates toward
+/// zero, which is WRONG for negative durations; `floor_div_i64` is exact.
+/// Identity used: floor((epoch_days*DAY + dur)/DAY) == epoch_days + floor(dur/DAY),
+/// because epoch_days*DAY is an exact multiple of DAY -- so flooring the duration
+/// to days and adding is equivalent to the F&O dateTime round-trip.
+/// Oracle (Python datetime, cast->dateTime@midnight->add->.date()): verified. [OPUS-4.8] (sq-3x7dl.18)
 pub fn date_add_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate {
     let dur_micros = dur.to_signed_micros();
-    // Convert microseconds to days (integer division)
-    let dur_days: i32 = (dur_micros / 86_400_000_000) as i32;
+    let dur_days: i32 = floor_div_i64(dur_micros, 86_400_000_000) as i32;
     let new_days = date.epoch_days + dur_days;
     XsdDate::new_with_tz(new_days, date.tz_offset_minutes)
 }
 
-/// op:subtract-dayTimeDuration-from-date
-/// Subtracts a dayTimeDuration from a date, returning a new date
+/// op:subtract-dayTimeDuration-from-date -- XPath F&O 3.1 (9.7.4)
+///
+/// Equivalent to op:add-dayTimeDuration-to-date with the negated duration, then
+/// floored to the day (see `date_add_duration`). We `floor_div_i64` the NEGATED
+/// duration so the midnight-crossing shift is correct under floor semantics:
+/// e.g. 1970-01-01 - PT1H = 1969-12-31 (truncating `/` wrongly stays 1970-01-01).
+/// Oracle (Python datetime): verified. [OPUS-4.8] (sq-3x7dl.18)
 pub fn date_subtract_duration(date: XsdDate, dur: XsdDayTimeDuration) -> XsdDate {
     let dur_micros = dur.to_signed_micros();
-    // Convert microseconds to days (integer division)
-    let dur_days: i32 = (dur_micros / 86_400_000_000) as i32;
-    let new_days = date.epoch_days - dur_days;
+    let dur_days: i32 = floor_div_i64(-dur_micros, 86_400_000_000) as i32;
+    let new_days = date.epoch_days + dur_days;
     XsdDate::new_with_tz(new_days, date.tz_offset_minutes)
 }
 
@@ -355,4 +368,58 @@ pub fn fn_dateTime(date: XsdDate, time: crate::types::XsdTime) -> crate::types::
     let total_micros_u64: u64 = total_micros as u64;
     // Use the timezone from the date (or time if they match)
     crate::types::XsdDateTime::new_with_tz(total_micros_u64 as Field, date.tz_offset_minutes)
+}
+
+// ============================================================================
+// Date +/- dayTimeDuration FLOOR-semantics tests (sq-3x7dl.18) [OPUS-4.8]
+//
+// XPath F&O 3.1 op:add/subtract-dayTimeDuration-(to/from)-date cast the date to
+// an xs:dateTime at midnight, apply the duration, then take the date component --
+// which FLOORS the instant to the whole day. Noir integer `/` truncates toward
+// zero, so a sub-day / negative duration crossing midnight was mishandled.
+// Expected calendar values are quoted from a Python oracle:
+//   (datetime(y,m,d, tzinfo=timezone.utc) -/+ timedelta(...)).date()
+//   epoch_days via (date(y,m,d) - date(1970,1,1)).days
+// ============================================================================
+
+#[test]
+fn test_date_subtract_subday_duration_crosses_midnight() {
+    // Oracle: 1970-01-01 - PT1H = 1969-12-31 (epoch_days -1). Truncating `/`
+    // would wrongly keep 1970-01-01 (epoch_days 0).
+    let epoch = date_from_epoch_days(0);
+    let one_hour = XsdDayTimeDuration::from_signed_micros(3_600_000_000);
+    let r = date_subtract_duration(epoch, one_hour);
+    assert(r.epoch_days == -1);
+    assert(year_from_date(r) == 1969);
+    assert(month_from_date(r) == 12);
+    assert(day_from_date(r) == 31);
+}
+
+#[test]
+fn test_date_add_negative_subday_duration_crosses_midnight() {
+    let epoch = date_from_epoch_days(0);
+    // Oracle: 1970-01-01 + (-PT1H) = 1969-12-31 (epoch_days -1).
+    let neg_one_hour = XsdDayTimeDuration::from_signed_micros(-3_600_000_000);
+    let r = date_add_duration(epoch, neg_one_hour);
+    assert(r.epoch_days == -1);
+
+    // Oracle: 1970-01-01 - PT25H = 1969-12-30 (epoch_days -2); truncating `/` -> -1.
+    let twentyfive_hours = XsdDayTimeDuration::from_signed_micros(90_000_000_000);
+    let r2 = date_subtract_duration(epoch, twentyfive_hours);
+    assert(r2.epoch_days == -2);
+    assert(day_from_date(r2) == 30);
+}
+
+#[test]
+fn test_date_add_duration_positive_whole_and_subday() {
+    // Positive path unchanged (floor == trunc for non-negative durations).
+    // Oracle: 2004-10-30 + P2DT2H30M = 2004-11-01 (epoch_days 12723).
+    let d = date_from_components(2004, 10, 30);
+    // P2DT2H30M = 2*86400e6 + 2*3600e6 + 30*60e6 = 181_800_000_000 microseconds.
+    let dur = XsdDayTimeDuration::from_signed_micros(181_800_000_000);
+    let r = date_add_duration(d, dur);
+    assert(r.epoch_days == 12723);
+    assert(year_from_date(r) == 2004);
+    assert(month_from_date(r) == 11);
+    assert(day_from_date(r) == 1);
 }

--- a/xpath/src/duration.nr
+++ b/xpath/src/duration.nr
@@ -158,24 +158,32 @@ pub fn duration_negate(dur: XsdDayTimeDuration) -> XsdDayTimeDuration {
 
 /// op:add-dayTimeDuration-to-dateTime
 /// Adds a duration to a dateTime
+///
+/// SIGNED EPOCH ENCODING (sq-3x7dl.7): the result may be a valid pre-1970
+/// (negative) instant -- e.g. 1970-01-01T00:00:00Z + (-P1D) = 1969-12-31T00:00:00Z
+/// is a perfectly valid xs:dateTime. We decode the operand epoch to i64, add the
+/// signed duration, and store the two's-complement 64-bit pattern of the signed
+/// result (`(e as u64) as Field`), exactly like datetime.nr's construction path.
+/// The old `assert(result >= 0, ...)` aborted the circuit on every valid
+/// pre-epoch op, so it is dropped. [OPUS-4.8] (sq-3x7dl.18)
 pub fn datetime_add_duration(dt: XsdDateTime, dur: XsdDayTimeDuration) -> XsdDateTime {
     let dt_micros: i64 = dt.epoch_microseconds as i64;
     let dur_micros = dur.to_signed_micros();
-    let result = dt_micros + dur_micros;
-    assert(result >= 0, "DateTime cannot be negative");
-    let result_u64: u64 = result as u64;
-    XsdDateTime::new(result_u64 as Field)
+    let result: i64 = dt_micros + dur_micros;
+    XsdDateTime::new((result as u64) as Field)
 }
 
 /// op:subtract-dayTimeDuration-from-dateTime
 /// Subtracts a duration from a dateTime
+///
+/// See `datetime_add_duration`: the difference may be a valid negative epoch, so
+/// we encode the signed result via `(result as u64) as Field` and drop the old
+/// non-negativity assert. [OPUS-4.8] (sq-3x7dl.18)
 pub fn datetime_subtract_duration(dt: XsdDateTime, dur: XsdDayTimeDuration) -> XsdDateTime {
     let dt_micros: i64 = dt.epoch_microseconds as i64;
     let dur_micros = dur.to_signed_micros();
-    let result = dt_micros - dur_micros;
-    assert(result >= 0, "DateTime cannot be negative");
-    let result_u64: u64 = result as u64;
-    XsdDateTime::new(result_u64 as Field)
+    let result: i64 = dt_micros - dur_micros;
+    XsdDateTime::new((result as u64) as Field)
 }
 
 /// op:subtract-dateTimes
@@ -308,4 +316,62 @@ fn test_duration_comparison() {
 
     assert(duration_greater_than(d2, d1) == true);
     assert(duration_greater_than(d1, d2) == false);
+}
+
+// ============================================================================
+// Signed-epoch (pre-1970) DateTime +/- Duration tests (sq-3x7dl.18) [OPUS-4.8]
+//
+// The signed-i64 epoch encoding (sq-3x7dl.7) makes pre-1970 instants valid
+// NEGATIVE epochs, so datetime_add_duration / datetime_subtract_duration must
+// NOT assert `result >= 0`. Every expected epoch below is quoted from an
+// INDEPENDENT timezone-aware Python oracle (datetime + timedelta):
+//   (dt - datetime(1970,1,1, tzinfo=timezone.utc)) // timedelta(microseconds=1)
+// ============================================================================
+
+/// Encode a signed i64 epoch as the canonical Field bit pattern (test helper,
+/// mirrors datetime.nr::signed_epoch).
+fn signed_epoch_us(e: i64) -> Field {
+    (e as u64) as Field
+}
+
+#[test]
+fn test_datetime_subtract_duration_epoch_minus_one_day() {
+    // (a) Oracle: 1970-01-01T00:00:00Z - P1D = 1969-12-31T00:00:00Z, epoch_us=-86400000000
+    let epoch = XsdDateTime::new(0);
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(epoch, one_day);
+    assert((result.epoch_microseconds as i64) == -86_400_000_000);
+
+    // Adding a NEGATIVE duration lands on the same negative epoch.
+    let neg_one_day = duration_from_components(true, 1, 0, 0, 0, 0);
+    let via_add = datetime_add_duration(epoch, neg_one_day);
+    assert((via_add.epoch_microseconds as i64) == -86_400_000_000);
+}
+
+#[test]
+fn test_datetime_negative_epoch_stays_negative() {
+    // (b) base 1969-07-20T20:17:40Z, epoch_us=-14182940000000
+    let base = XsdDateTime::new(signed_epoch_us(-14_182_940_000_000));
+
+    // minus P2D stays negative. Oracle: 1969-07-18T20:17:40Z, epoch_us=-14355740000000
+    let two_days = duration_from_components(false, 2, 0, 0, 0, 0);
+    let minus = datetime_subtract_duration(base, two_days);
+    assert((minus.epoch_microseconds as i64) == -14_355_740_000_000);
+
+    // plus PT1H stays negative. Oracle: 1969-07-20T21:17:40Z, epoch_us=-14179340000000
+    let one_hour = duration_from_components(false, 0, 1, 0, 0, 0);
+    let plus = datetime_add_duration(base, one_hour);
+    assert((plus.epoch_microseconds as i64) == -14_179_340_000_000);
+}
+
+#[test]
+fn test_datetime_negative_epoch_crosses_back_over_1970() {
+    // (c) base 1969-12-31T12:00:00Z, epoch_us=-43200000000
+    let base = XsdDateTime::new(signed_epoch_us(-43_200_000_000));
+    // plus P1D crosses forward to 1970-01-01T12:00:00Z, epoch_us=43200000000 (positive)
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let crossed = datetime_add_duration(base, one_day);
+    assert((crossed.epoch_microseconds as i64) == 43_200_000_000);
+    // The positive result's raw Field equals the plain unsigned value too.
+    assert(crossed.epoch_microseconds == 43_200_000_000);
 }


### PR DESCRIPTION
## Summary

> 🤖 **SPARQ agent** — re-sync the sparq-org/noir_XPath published face after sparq PR #1523 merged (sq-zqtd3). This is a mechanical re-export of the in-tree zk/xpath surface; no design decisions were made here.

- **`duration.nr`** — `datetime_add_duration` / `datetime_subtract_duration` now decode the operand to `i64`, apply the signed duration, and store the two's-complement 64-bit pattern via `(result as u64) as Field`, removing the old `assert(result >= 0)` that aborted valid pre-1970 DateTime arithmetic. Adds three Python-oracle-verified regression tests for the new signed-epoch path (sq-3x7dl.7 / sq-3x7dl.18).
- **`date.nr`** — `date_add_duration` / `date_subtract_duration` switch from truncating integer `/` to `floor_div_i64` so sub-day or negative durations that cross midnight are handled correctly per XPath F&O 3.1 op:add-dayTimeDuration-to-date semantics (e.g. 1970-01-01 − PT1H → 1969-12-31). Adds three Python-oracle-verified regression tests (sq-3x7dl.18).

No other source files changed; `xpath/Nargo.toml` vendor path is intentionally preserved for the standalone structure.

## Verification

- Recursive diff against `sparq origin/main zk/xpath/` shows only the expected structural differences remain (CI workflows, vendored ieee754, Nargo.toml path)
- `nargo test --package xpath` → **134/134 tests pass** on nargo 1.0.0-beta.21 (pinned CI version)

## Notes

- Required status `copilot-review-posted` has no producer workflow (tracked as sparq bead sq-umj0p) — the honest manual status will be posted once Copilot's review is visible and checks are otherwise green.
- Open Dependabot PR #41 (actions/checkout bump) noted — independent of this change.

## Test plan

- [x] `nargo test --package xpath` passes (134/134) on nargo 1.0.0-beta.21
- [x] Recursive diff confirms only duration.nr + date.nr changed in the source tree
- [x] New tests verified against independent Python oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)