### PR TITLE
sync: batch re-sync #3 from sparq PRs #1541/#1547/#1550 (sq-tlu1z)

### DIFF
--- a/test_packages/xpath_test_fncontains/src/chunk_0.nr
+++ b/test_packages/xpath_test_fncontains/src/chunk_0.nr
@@ -1,8 +1,98 @@
-//! Test chunk 0 for fn:contains
-//! Contains 1 tests
+//! Real test vectors for fn:contains (F&O sec. 7.5.3)
+//! Python oracle: str.__contains__; "" in x is always True; NUL padding = logical terminator.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::contains;
 
 #[test]
-fn fncontains_no_converted_tests() {
-    // Placeholder: 68 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:contains");
+fn fncontains_tattoo_tat() {
+    // Python: "tat" in "tattoo" -> True
+    let s: str<6> = "tattoo";
+    let n: str<3> = "tat";
+    assert(contains::<6, 3>(s, n));
+}
+
+#[test]
+fn fncontains_tattoo_tow_false() {
+    // Python: "tow" in "tattoo" -> False
+    let s: str<6> = "tattoo";
+    let n: str<3> = "tow";
+    assert(!contains::<6, 3>(s, n));
+}
+
+#[test]
+fn fncontains_any_empty_needle() {
+    // F&O sec.7.5.3: fn:contains($arg1, "") = true for any $arg1
+    // Python: "" in "tattoo" -> True
+    let s: str<6> = "tattoo";
+    let n: str<0> = "";
+    assert(contains::<6, 0>(s, n));
+}
+
+#[test]
+fn fncontains_empty_both() {
+    // Python: "" in "" -> True
+    let s: str<0> = "";
+    let n: str<0> = "";
+    assert(contains::<0, 0>(s, n));
+}
+
+#[test]
+fn fncontains_empty_haystack_nonempty_needle() {
+    // Python: "x" in "" -> False
+    let s: str<1> = "\0";
+    let n: str<1> = "x";
+    assert(!contains::<1, 1>(s, n));
+}
+
+#[test]
+fn fncontains_padded_needle_midstring() {
+    // Python: "ell" in "hello" -> True; needle "ell" in str<6> (NUL-padded)
+    // Logical-length semantics: NUL padding is not content.
+    let s: str<5> = "hello";
+    let n: str<6> = "ell\0\0\0";
+    assert(contains::<5, 6>(s, n));
+}
+
+#[test]
+fn fncontains_needle_equals_haystack() {
+    // Python: "hello" in "hello" -> True (exact match)
+    let s: str<5> = "hello";
+    let n: str<5> = "hello";
+    assert(contains::<5, 5>(s, n));
+}
+
+#[test]
+fn fncontains_needle_longer_than_haystack() {
+    // Python: "hello world" in "hello" -> False
+    let s: str<5> = "hello";
+    let n: str<5> = "world";
+    assert(!contains::<5, 5>(s, n));
+}
+
+#[test]
+fn fncontains_at_start_of_full_buffer() {
+    // Full-buffer: haystack fills capacity, needle at start.
+    // Python: "abc" in "abcdefgh" -> True
+    let s: str<8> = "abcdefgh";
+    let n: str<3> = "abc";
+    assert(contains::<8, 3>(s, n));
+}
+
+#[test]
+fn fncontains_at_end_of_full_buffer() {
+    // Full-buffer: haystack fills capacity, needle at end.
+    // Python: "fgh" in "abcdefgh" -> True
+    let s: str<8> = "abcdefgh";
+    let n: str<3> = "fgh";
+    assert(contains::<8, 3>(s, n));
+}
+
+#[test]
+fn fncontains_logically_empty_haystack() {
+    // Haystack has capacity but logical content is empty (all NUL).
+    // Python: "" in "" -> True (empty needle), "x" in "" -> False.
+    let s: str<4> = "\0\0\0\0";
+    let n_empty: str<0> = "";
+    assert(contains::<4, 0>(s, n_empty));
 }

--- a/test_packages/xpath_test_fnends_with/src/chunk_0.nr
+++ b/test_packages/xpath_test_fnends_with/src/chunk_0.nr
@@ -1,8 +1,89 @@
-//! Test chunk 0 for fn:ends-with
-//! Contains 1 tests
+//! Real test vectors for fn:ends-with (F&O sec. 7.5.2)
+//! Python oracle: str.endswith; empty suffix always matches.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::ends_with;
 
 #[test]
-fn fnends_with_no_converted_tests() {
-    // Placeholder: 49 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:ends-with");
+fn fnends_with_tattoo_oo() {
+    // Python: "tattoo".endswith("oo") -> True
+    let s: str<6> = "tattoo";
+    let suf: str<2> = "oo";
+    assert(ends_with::<6, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_tattoo_ta_false() {
+    // Python: "tattoo".endswith("ta") -> False (prefix, not suffix)
+    let s: str<6> = "tattoo";
+    let suf: str<2> = "ta";
+    assert(!ends_with::<6, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_tattoo_tattoo() {
+    // Python: "tattoo".endswith("tattoo") -> True (full string suffix)
+    let s: str<6> = "tattoo";
+    let suf: str<6> = "tattoo";
+    assert(ends_with::<6, 6>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_suffix() {
+    // F&O sec.7.5.2: fn:ends-with($arg1, "") = true for any $arg1
+    // Python: "tattoo".endswith("") -> True
+    let s: str<6> = "tattoo";
+    let suf: str<0> = "";
+    assert(ends_with::<6, 0>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_both() {
+    // Python: "".endswith("") -> True
+    let s: str<0> = "";
+    let suf: str<0> = "";
+    assert(ends_with::<0, 0>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_haystack_nonempty_suffix() {
+    // Python: "".endswith("x") -> False
+    let s: str<1> = "\0";
+    let suf: str<1> = "x";
+    assert(!ends_with::<1, 1>(s, suf));
+}
+
+#[test]
+fn fnends_with_suffix_longer_than_haystack() {
+    // Python: "lo".endswith("hello") -> False
+    let s: str<2> = "lo";
+    let suf: str<5> = "hello";
+    assert(!ends_with::<2, 5>(s, suf));
+}
+
+#[test]
+fn fnends_with_nul_padded_haystack_logical_length() {
+    // "hello" stored in str<10>; logical end is after 'o', not at capacity.
+    // Python: "hello".endswith("lo") -> True
+    let s: str<10> = "hello\0\0\0\0\0";
+    let suf: str<2> = "lo";
+    assert(ends_with::<10, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_nul_padded_suffix() {
+    // Suffix "lo" stored in str<5> (NUL-padded); logical suffix length=2.
+    // Python: "hello".endswith("lo") -> True
+    let s: str<5> = "hello";
+    let suf: str<5> = "lo\0\0\0";
+    assert(ends_with::<5, 5>(s, suf));
+}
+
+#[test]
+fn fnends_with_full_buffer() {
+    // Full-buffer haystack, suffix at end.
+    // Python: "abcdefgh".endswith("fgh") -> True
+    let s: str<8> = "abcdefgh";
+    let suf: str<3> = "fgh";
+    assert(ends_with::<8, 3>(s, suf));
 }

--- a/test_packages/xpath_test_fnstarts_with/src/chunk_0.nr
+++ b/test_packages/xpath_test_fnstarts_with/src/chunk_0.nr
@@ -1,8 +1,89 @@
-//! Test chunk 0 for fn:starts-with
-//! Contains 1 tests
+//! Real test vectors for fn:starts-with (F&O sec. 7.5.1)
+//! Python oracle: str.startswith; empty prefix always matches.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::starts_with;
 
 #[test]
-fn fnstarts_with_no_converted_tests() {
-    // Placeholder: 58 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:starts-with");
+fn fnstarts_with_tattoo_tat() {
+    // Python: "tattoo".startswith("tat") -> True
+    let s: str<6> = "tattoo";
+    let pfx: str<3> = "tat";
+    assert(starts_with::<6, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_tow_false() {
+    // Python: "tattoo".startswith("tow") -> False
+    let s: str<6> = "tattoo";
+    let pfx: str<3> = "tow";
+    assert(!starts_with::<6, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_full() {
+    // Python: "tattoo".startswith("tattoo") -> True (full match)
+    let s: str<6> = "tattoo";
+    let pfx: str<6> = "tattoo";
+    assert(starts_with::<6, 6>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_too_long_false() {
+    // Python: "tattoo".startswith("tattoox") -> False
+    let s: str<6> = "tattoo";
+    let pfx: str<7> = "tattoox";
+    assert(!starts_with::<6, 7>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_prefix() {
+    // F&O sec.7.5.1: fn:starts-with($arg1, "") = true for any $arg1
+    // Python: "tattoo".startswith("") -> True
+    let s: str<6> = "tattoo";
+    let pfx: str<0> = "";
+    assert(starts_with::<6, 0>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_both() {
+    // Python: "".startswith("") -> True
+    let s: str<0> = "";
+    let pfx: str<0> = "";
+    assert(starts_with::<0, 0>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_haystack_nonempty_prefix() {
+    // Python: "".startswith("x") -> False
+    let s: str<1> = "\0";
+    let pfx: str<1> = "x";
+    assert(!starts_with::<1, 1>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_nul_padded_prefix() {
+    // "he" stored in str<5> (NUL-padded); logical prefix length=2.
+    // Python: "hello".startswith("he") -> True
+    let s: str<5> = "hello";
+    let pfx: str<5> = "he\0\0\0";
+    assert(starts_with::<5, 5>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_nul_padded_haystack() {
+    // "hello" in str<10>; logical content = 5 bytes.
+    // Python: "hello".startswith("hel") -> True
+    let s: str<10> = "hello\0\0\0\0\0";
+    let pfx: str<3> = "hel";
+    assert(starts_with::<10, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_full_buffer() {
+    // Full-buffer haystack, prefix at start.
+    // Python: "abcdefgh".startswith("abc") -> True
+    let s: str<8> = "abcdefgh";
+    let pfx: str<3> = "abc";
+    assert(starts_with::<8, 3>(s, pfx));
 }

--- a/test_packages/xpath_test_fnstring_length/src/chunk_0.nr
+++ b/test_packages/xpath_test_fnstring_length/src/chunk_0.nr
@@ -1,8 +1,76 @@
-//! Test chunk 0 for fn:string-length
-//! Contains 1 tests
+//! Real test vectors for fn:string-length (F&O sec. 7.4.1)
+//! Counts Unicode codepoints (lead bytes in well-formed UTF-8), NOT bytes.
+//! Python oracle: len(str) - Python strings are codepoint sequences.
+//! NUL = logical terminator (not U+0000 content); padded bytes not counted.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::string_length;
 
 #[test]
-fn fnstring_length_no_converted_tests() {
-    // Placeholder: 29 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:string-length");
+fn fnstring_length_hello() {
+    // Python: len("hello") -> 5
+    let s: str<5> = "hello";
+    assert(string_length::<5>(s) == 5);
+}
+
+#[test]
+fn fnstring_length_empty() {
+    // F&O sec.7.4.1: fn:string-length("") = 0
+    // Python: len("") -> 0
+    let s: str<0> = "";
+    assert(string_length::<0>(s) == 0);
+}
+
+#[test]
+fn fnstring_length_single_char() {
+    // Python: len("a") -> 1
+    let s: str<1> = "a";
+    assert(string_length::<1>(s) == 1);
+}
+
+#[test]
+fn fnstring_length_e_acute_one_codepoint() {
+    // Python: len(U+00E9 e-acute) -> 1 (2 UTF-8 bytes, 1 codepoint)
+    // UTF-8 bytes: [0xC3, 0xA9] = [195, 169]; lead byte count = 1.
+    let s: str<2> = "é";
+    assert(string_length::<2>(s) == 1);
+}
+
+#[test]
+fn fnstring_length_mixed_ascii_multibyte() {
+    // Python: len("a" + U+00E9) -> 2 (1 ASCII + 1 two-byte codepoint = 3 bytes, 2 codepoints)
+    let s: str<3> = "aé";
+    assert(string_length::<3>(s) == 2);
+}
+
+#[test]
+fn fnstring_length_nul_padded_stops_at_nul() {
+    // "hello" stored in str<10>; logical content = 5 bytes; NUL padding ignored.
+    // Python: len("hello") -> 5
+    let s: str<10> = "hello\0\0\0\0\0";
+    assert(string_length::<10>(s) == 5);
+}
+
+#[test]
+fn fnstring_length_full_buffer() {
+    // Full-buffer: "abcdefgh" fills str<8>; all 8 bytes are content (no NUL).
+    // Python: len("abcdefgh") -> 8
+    let s: str<8> = "abcdefgh";
+    assert(string_length::<8>(s) == 8);
+}
+
+#[test]
+fn fnstring_length_known_example() {
+    // F&O spec example: fn:string-length("Harp not on that string, madam; that string") = 43
+    // Python: len("Harp not on that string, madam; that string") -> 43
+    let s: str<43> = "Harp not on that string, madam; that string";
+    assert(string_length::<43>(s) == 43);
+}
+
+#[test]
+fn fnstring_length_logically_empty_padded_buffer() {
+    // Capacity-4 buffer with all NUL bytes -> logical length = 0.
+    // Python: len("") -> 0
+    let s: str<4> = "\0\0\0\0";
+    assert(string_length::<4>(s) == 0);
 }

--- a/test_packages/xpath_test_opadd_daytimeduration_to_datetime/src/chunk_0.nr
+++ b/test_packages/xpath_test_opadd_daytimeduration_to_datetime/src/chunk_0.nr
@@ -1,8 +1,90 @@
-//! Test chunk 0 for op:add-dayTimeDuration-to-dateTime
-//! Contains 1 tests
+//! Real test vectors for op:add-dayTimeDuration-to-dateTime (F&O sec. 8.3.17)
+//! Signed epoch encoding: pre-1970 results are VALID negative i64 epochs.
+//! Python oracle (tz-aware datetime):
+//!   from datetime import datetime, timezone, timedelta
+//!   def epoch_us(dt): return int((dt - datetime(1970,1,1,tzinfo=timezone.utc)).total_seconds() * 1_000_000)
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{datetime_add_duration, duration_from_components, XsdDateTime};
+
+/// Encode a signed i64 epoch as the canonical Field bit pattern
+/// (mirrors the pattern in duration.nr test helpers).
+fn signed_epoch_us(e: i64) -> Field {
+    (e as u64) as Field
+}
 
 #[test]
-fn opadd_daytimeduration_to_datetime_no_converted_tests() {
-    // Placeholder: 21 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for op:add-dayTimeDuration-to-dateTime");
+fn opadd_dt_dtd_epoch_plus_one_day() {
+    // Oracle: 1970-01-01T00:00:00Z + P1D = 1970-01-02T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,2,tzinfo=timezone.utc)) -> 86400000000
+    let dt = XsdDateTime::new(0);
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_epoch_plus_neg_one_day_pre1970() {
+    // Oracle: 1970-01-01T00:00:00Z + (-P1D) = 1969-12-31T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,31,tzinfo=timezone.utc)) -> -86400000000
+    // Signed epoch: negative result is valid (sq-3x7dl.7).
+    let dt = XsdDateTime::new(0);
+    let neg_one_day = duration_from_components(true, 1, 0, 0, 0, 0); // negative=true
+    let result = datetime_add_duration(dt, neg_one_day);
+    assert((result.epoch_microseconds as i64) == -86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_pre1970_plus_two_days_cross_epoch() {
+    // Oracle: 1969-12-31T00:00:00Z + P2D = 1970-01-02T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,2,tzinfo=timezone.utc)) -> 86400000000
+    // Crossing 1970 boundary: negative -> positive.
+    let dt = XsdDateTime::new(signed_epoch_us(-86_400_000_000));
+    let two_days = duration_from_components(false, 2, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, two_days);
+    assert((result.epoch_microseconds as i64) == 86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_zero_duration() {
+    // Oracle: 1970-01-01T00:00:00Z + PT0S = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(0);
+    let zero = duration_from_components(false, 0, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, zero);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opadd_dt_dtd_year_2000_plus_one_day() {
+    // Oracle: 2000-01-01T00:00:00Z + P1D = 2000-01-02T00:00:00Z
+    // Python: epoch_us(datetime(2000,1,1,tzinfo=timezone.utc)) -> 946684800000000
+    //         epoch_us(datetime(2000,1,2,tzinfo=timezone.utc)) -> 946771200000000
+    let base_us: i64 = 946_684_800_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 946_771_200_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_epoch_plus_one_hour_thirty_min() {
+    // Oracle: 1970-01-01T00:00:00Z + PT1H30M = 1970-01-01T01:30:00Z
+    // Python: epoch_us(datetime(1970,1,1,1,30,tzinfo=timezone.utc)) -> 5400000000
+    let dt = XsdDateTime::new(0);
+    let dur = duration_from_components(false, 0, 1, 30, 0, 0);
+    let result = datetime_add_duration(dt, dur);
+    assert((result.epoch_microseconds as i64) == 5_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_deep_pre1970() {
+    // Oracle: 1969-07-20T20:17:40Z + PT1H = 1969-07-20T21:17:40Z
+    // Python: epoch_us(datetime(1969,7,20,20,17,40,tzinfo=timezone.utc)) -> -14182940000000
+    //         epoch_us(datetime(1969,7,20,21,17,40,tzinfo=timezone.utc)) -> -14179340000000
+    let base_us: i64 = -14_182_940_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_hour = duration_from_components(false, 0, 1, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_hour);
+    assert((result.epoch_microseconds as i64) == -14_179_340_000_000);
 }

--- a/test_packages/xpath_test_opnotation_equal/src/chunk_0.nr
+++ b/test_packages/xpath_test_opnotation_equal/src/chunk_0.nr
@@ -1,8 +1,72 @@
-//! Test chunk 0 for op:NOTATION-equal
-//! Contains 1 tests
+//! Real test vectors for op:NOTATION-equal (F&O sec. 9.1)
+//! op:NOTATION-equal($arg1 as xs:NOTATION, $arg2 as xs:NOTATION) as xs:boolean
+//! xs:NOTATION equality is by expanded name (namespace URI + local name),
+//! identical to xs:QName equality (F&O sec. 9.1). Oracle: XPath F&O 3.2 sec. 9.1.
+//! Implementation delegates to qname_equal (same type, same semantics).
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{notation_equal, XsdQName};
 
 #[test]
-fn opnotation_equal_no_converted_tests() {
-    // Placeholder: 20 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for op:NOTATION-equal");
+fn opnotation_equal_same_ns_same_local() {
+    // Same namespace URI and same local name -> equal.
+    // Oracle F&O sec.9.1: identity of expanded names.
+    let ns = "http://example.com".as_bytes();
+    let loc = "foo".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns, 18, loc, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns, 18, loc, 3);
+    assert(notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_same_ns_different_local() {
+    // Same NS but different local names -> not equal.
+    // Oracle F&O sec.9.1: local name must match.
+    let ns = "http://example.com".as_bytes();
+    let loc_a = "foo".as_bytes();
+    let loc_b = "bar".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns, 18, loc_a, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns, 18, loc_b, 3);
+    assert(!notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_different_ns_same_local() {
+    // Different NS, same local name -> not equal.
+    // Oracle F&O sec.9.1: namespace URI must match.
+    let ns_a = "http://example.com".as_bytes();
+    let ns_b = "http://other.org  ".as_bytes(); // same length, different content
+    let loc = "foo".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns_a, 18, loc, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns_b, 18, loc, 3);
+    assert(!notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_no_namespace_same_local() {
+    // No-namespace NOTATION values: equality by local name only.
+    // Oracle F&O sec.9.1: empty namespace URI is a valid expanded name.
+    let loc = "mynotation".as_bytes();
+    let a: XsdQName<0, 10> = XsdQName::from_local_name(loc, 10);
+    let b: XsdQName<0, 10> = XsdQName::from_local_name(loc, 10);
+    assert(notation_equal::<0, 10, 0, 10>(a, b));
+}
+
+#[test]
+fn opnotation_equal_no_namespace_different_local() {
+    // No-namespace NOTATIONs with different local names -> not equal.
+    let loc_a = "nota1     ".as_bytes();
+    let loc_b = "nota2     ".as_bytes();
+    let a: XsdQName<0, 10> = XsdQName::from_local_name(loc_a, 5);
+    let b: XsdQName<0, 10> = XsdQName::from_local_name(loc_b, 5);
+    assert(!notation_equal::<0, 10, 0, 10>(a, b));
+}
+
+#[test]
+fn opnotation_equal_reflexivity() {
+    // Every NOTATION must equal itself (reflexivity).
+    let ns = "http://www.w3.org/TR/".as_bytes();
+    let loc = "html".as_bytes();
+    let a: XsdQName<21, 4> = XsdQName::new(ns, 21, loc, 4);
+    assert(notation_equal::<21, 4, 21, 4>(a, a));
 }

--- a/test_packages/xpath_test_opsubtract_daytimeduration_from_datetime/src/chunk_0.nr
+++ b/test_packages/xpath_test_opsubtract_daytimeduration_from_datetime/src/chunk_0.nr
@@ -1,11 +1,86 @@
-//! Test chunk 0 for op:subtract-dayTimeDuration-from-dateTime
-//! Contains 1 tests
+//! Real test vectors for op:subtract-dayTimeDuration-from-dateTime (F&O sec. 8.3.18)
+//! Signed epoch encoding: pre-1970 results are VALID negative i64 epochs.
+//! Python oracle (tz-aware datetime):
+//!   from datetime import datetime, timezone, timedelta
+//!   def epoch_us(dt): return int((dt - datetime(1970,1,1,tzinfo=timezone.utc)).total_seconds() * 1_000_000)
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{datetime_subtract_duration, duration_from_components, XsdDateTime};
+
+fn signed_epoch_us(e: i64) -> Field {
+    (e as u64) as Field
+}
 
 #[test]
-fn opsubtract_daytimeduration_from_datetime_no_converted_tests() {
-    // Placeholder: 21 qt3tests cases could not be converted.
-    assert(
-        false,
-        "No qt3tests cases could be converted for op:subtract-dayTimeDuration-from-dateTime",
-    );
+fn opsubtract_dt_dtd_epoch_minus_one_day_pre1970() {
+    // Oracle: 1970-01-01T00:00:00Z - P1D = 1969-12-31T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,31,tzinfo=timezone.utc)) -> -86400000000
+    let dt = XsdDateTime::new(0);
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -86_400_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_day2_minus_one_day() {
+    // Oracle: 1970-01-02T00:00:00Z - P1D = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(signed_epoch_us(86_400_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opsubtract_dt_dtd_year_2000_minus_one_day() {
+    // Oracle: 2000-01-02T00:00:00Z - P1D = 2000-01-01T00:00:00Z
+    // Python: epoch_us(datetime(2000,1,2,tzinfo=timezone.utc)) -> 946771200000000
+    //         epoch_us(datetime(2000,1,1,tzinfo=timezone.utc)) -> 946684800000000
+    let dt = XsdDateTime::new(signed_epoch_us(946_771_200_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 946_684_800_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_pre1970_minus_one_day_deeper() {
+    // Oracle: 1969-12-31T00:00:00Z - P1D = 1969-12-30T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,30,tzinfo=timezone.utc)) -> -172800000000
+    let dt = XsdDateTime::new(signed_epoch_us(-86_400_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -172_800_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_zero_duration() {
+    // Oracle: 1970-01-01T00:00:00Z - PT0S = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(0);
+    let zero = duration_from_components(false, 0, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, zero);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opsubtract_dt_dtd_pre1970_minus_one_hour() {
+    // Oracle: 1969-07-20T21:17:40Z - PT1H = 1969-07-20T20:17:40Z
+    // Python: epoch_us(datetime(1969,7,20,21,17,40,tzinfo=timezone.utc)) -> -14179340000000
+    //         epoch_us(datetime(1969,7,20,20,17,40,tzinfo=timezone.utc)) -> -14182940000000
+    let base_us: i64 = -14_179_340_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_hour = duration_from_components(false, 0, 1, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_hour);
+    assert((result.epoch_microseconds as i64) == -14_182_940_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_crosses_1970_boundary() {
+    // Oracle: 1970-01-01T12:00:00Z - P1D = 1969-12-31T12:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,12,tzinfo=timezone.utc)) -> 43200000000
+    //         epoch_us(datetime(1969,12,31,12,tzinfo=timezone.utc)) -> -43200000000
+    let dt = XsdDateTime::new(signed_epoch_us(43_200_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -43_200_000_000);
 }

--- a/xpath/src/duration.nr
+++ b/xpath/src/duration.nr
@@ -8,8 +8,14 @@
 //! - op:multiply-dayTimeDuration, op:divide-dayTimeDuration
 //! - op:add-dayTimeDuration-to-dateTime, op:subtract-dayTimeDuration-from-dateTime
 //! - op:dayTimeDuration-equal, op:dayTimeDuration-less-than, op:dayTimeDuration-greater-than
+//! XPath functions implemented (generic dispatch on the duration subtype):
+//! - fn:years-from-duration (xs:dayTimeDuration -> 0 per F&O sec. 8.4.3,
+//!   xs:yearMonthDuration -> real years)
+//! - fn:months-from-duration (xs:dayTimeDuration -> 0 per F&O sec. 8.4.4,
+//!   xs:yearMonthDuration -> real months)
 
 use crate::types::{XsdDateTime, XsdDayTimeDuration};
+use crate::year_month_duration::XsdYearMonthDuration;
 
 // ============================================================================
 // Time Constants (as i64 for signed arithmetic)
@@ -104,6 +110,61 @@ pub fn seconds_from_duration(dur: XsdDayTimeDuration) -> u8 {
     let abs_micros: i64 = if micros < 0 { -micros } else { micros };
     let minute_remainder = abs_micros % MICROS_PER_MINUTE;
     (minute_remainder / MICROS_PER_SECOND) as u8
+}
+
+/// Dispatch trait for fn:years-from-duration / fn:months-from-duration across
+/// the two XSD duration subtypes (F&O sec. 8.4.3 / sec. 8.4.4). The generated
+/// qt3tests packages call the accessors under their canonical XPath names with
+/// either subtype, so dispatch follows the codebase's generic trait-bound
+/// pattern (see comparison.nr). [SONNET-4.6] (sq-u91ki)
+pub trait YearMonthComponents {
+    /// Years component of the duration (F&O sec. 8.4.3)
+    fn years_component(self) -> i32;
+    /// Months component of the duration (F&O sec. 8.4.4)
+    fn months_component(self) -> i32;
+}
+
+/// F&O sec. 8.4.3 / sec. 8.4.4: an xs:dayTimeDuration carries no years or
+/// months component, so both accessors return the xs:integer 0.
+/// [SONNET-4.6] (sq-u91ki)
+impl YearMonthComponents for XsdDayTimeDuration {
+    fn years_component(self) -> i32 {
+        let _ = self;
+        0
+    }
+    fn months_component(self) -> i32 {
+        let _ = self;
+        0
+    }
+}
+
+/// xs:yearMonthDuration keeps its real component values -- delegates to the
+/// concrete accessors in year_month_duration.nr. [SONNET-4.6] (sq-u91ki)
+impl YearMonthComponents for XsdYearMonthDuration {
+    fn years_component(self) -> i32 {
+        crate::year_month_duration::years_from_duration(self)
+    }
+    fn months_component(self) -> i32 {
+        crate::year_month_duration::months_from_duration(self)
+    }
+}
+
+/// fn:years-from-duration -- dispatches on the duration subtype:
+/// xs:dayTimeDuration -> 0 (F&O sec. 8.4.3), xs:yearMonthDuration -> real years.
+pub fn years_from_duration<T>(dur: T) -> i32
+where
+    T: YearMonthComponents,
+{
+    dur.years_component()
+}
+
+/// fn:months-from-duration -- dispatches on the duration subtype:
+/// xs:dayTimeDuration -> 0 (F&O sec. 8.4.4), xs:yearMonthDuration -> real months.
+pub fn months_from_duration<T>(dur: T) -> i32
+where
+    T: YearMonthComponents,
+{
+    dur.months_component()
 }
 
 // ============================================================================
@@ -374,4 +435,73 @@ fn test_datetime_negative_epoch_crosses_back_over_1970() {
     assert((crossed.epoch_microseconds as i64) == 43_200_000_000);
     // The positive result's raw Field equals the plain unsigned value too.
     assert(crossed.epoch_microseconds == 43_200_000_000);
+}
+
+// ============================================================================
+// DayTimeDuration overloads for fn:years-from-duration / fn:months-from-duration
+// (sq-u91ki) [SONNET-4.6]
+//
+// F&O sec. 8.4.3 (fn:years-from-duration) and sec. 8.4.4 (fn:months-from-duration):
+// when the argument is xs:dayTimeDuration, both accessors return the xs:integer 0
+// because a dayTimeDuration carries no months or years component.
+//
+// Oracle: Python reference
+//   import isodate; d = isodate.parse_duration("P1D")
+//   # d is datetime.timedelta(days=1); no years/months attribute -> 0
+// ============================================================================
+
+#[test]
+fn test_years_from_duration_dt_positive() {
+    // Oracle: xs:dayTimeDuration("P1D") has no years component -> fn:years-from-duration = 0
+    // (F&O sec. 8.4.3)
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    assert(years_from_duration(one_day) == 0);
+}
+
+#[test]
+fn test_years_from_duration_dt_negative() {
+    // Oracle: xs:dayTimeDuration("-P365D") has no years component -> fn:years-from-duration = 0
+    // (F&O sec. 8.4.3)
+    let neg_year = duration_from_components(true, 365, 0, 0, 0, 0);
+    assert(years_from_duration(neg_year) == 0);
+}
+
+#[test]
+fn test_months_from_duration_dt_positive() {
+    // Oracle: xs:dayTimeDuration("P30D") has no months component -> fn:months-from-duration = 0
+    // (F&O sec. 8.4.4)
+    let thirty_days = duration_from_components(false, 30, 0, 0, 0, 0);
+    assert(months_from_duration(thirty_days) == 0);
+}
+
+#[test]
+fn test_months_from_duration_dt_negative() {
+    // Oracle: xs:dayTimeDuration("-P30D") has no months component -> fn:months-from-duration = 0
+    // (F&O sec. 8.4.4)
+    let neg_thirty_days = duration_from_components(true, 30, 0, 0, 0, 0);
+    assert(months_from_duration(neg_thirty_days) == 0);
+}
+
+#[test]
+fn test_years_months_dt_zero_duration() {
+    // Regression: zero dayTimeDuration -> both return 0 (degenerate case, F&O sec. 8.4.3/8.4.4)
+    let zero = duration_zero();
+    assert(years_from_duration(zero) == 0);
+    assert(months_from_duration(zero) == 0);
+}
+
+#[test]
+fn test_years_months_from_duration_ym_regression() {
+    // Regression guard: the yearMonthDuration path through the SAME generic
+    // accessors must still return real component values (not the dayTimeDuration 0).
+    // Oracle: P2Y3M = 27 months -> years 2, months 3; -P1Y6M = -18 months ->
+    // years -1, months -6 (i32 truncating division, matching
+    // year_month_duration.nr::test_ym_duration_components).
+    let ym = XsdYearMonthDuration::new(27);
+    assert(years_from_duration(ym) == 2);
+    assert(months_from_duration(ym) == 3);
+
+    let ym_neg = XsdYearMonthDuration::new(-18);
+    assert(years_from_duration(ym_neg) == -1);
+    assert(months_from_duration(ym_neg) == -6);
 }

--- a/xpath/src/lib.nr
+++ b/xpath/src/lib.nr
@@ -67,19 +67,20 @@ pub mod xpath_xs;
 pub use types::{XsdDate, XsdDateTime, XsdDayTimeDuration, XsdTime};
 
 // Re-export YearMonthDuration type and functions
+// (months_from_duration / years_from_duration are exported from `duration` below:
+// the generic YearMonthComponents dispatch covers BOTH duration subtypes, sq-u91ki)
 pub use year_month_duration::{
     date_add_ym_duration, date_subtract_ym_duration, datetime_add_ym_duration,
-    datetime_subtract_ym_duration, fn_string_from_ym_duration, months_from_duration,
-    XsdYearMonthDuration, years_from_duration, ym_duration_add, ym_duration_divide,
-    ym_duration_divide_by_duration, ym_duration_equal, ym_duration_from_string, ym_duration_ge,
-    ym_duration_greater_than, ym_duration_le, ym_duration_less_than, ym_duration_multiply,
-    ym_duration_negate, ym_duration_subtract,
+    datetime_subtract_ym_duration, fn_string_from_ym_duration, XsdYearMonthDuration,
+    ym_duration_add, ym_duration_divide, ym_duration_divide_by_duration, ym_duration_equal,
+    ym_duration_from_string, ym_duration_ge, ym_duration_greater_than, ym_duration_le,
+    ym_duration_less_than, ym_duration_multiply, ym_duration_negate, ym_duration_subtract,
 };
 
 // Re-export QName type and functions
 pub use qname::{
     fn_qname, fn_qname_from_strings, local_name_from_qname, namespace_uri_from_qname,
-    prefix_from_qname, qname_equal, XsdQName,
+    notation_equal, prefix_from_qname, qname_equal, XsdQName,
 };
 
 // Re-export Gregorian types
@@ -160,7 +161,8 @@ pub use duration::{
     duration_from_components, duration_from_microseconds, duration_ge, duration_greater_than,
     duration_is_negative, duration_le, duration_less_than, duration_multiply, duration_negate,
     duration_subtract, duration_to_microseconds, duration_zero, hours_from_duration,
-    minutes_from_duration, seconds_from_duration,
+    minutes_from_duration, months_from_duration, seconds_from_duration, YearMonthComponents,
+    years_from_duration,
 };
 
 // Re-export date functions

--- a/xpath/src/qname.nr
+++ b/xpath/src/qname.nr
@@ -175,6 +175,19 @@ pub fn prefix_from_qname<let NS_LEN: u32, let LOCAL_LEN: u32, let PREFIX_LEN: u3
     ([0; PREFIX_LEN], 0)
 }
 
+/// op:NOTATION-equal
+/// Two xs:NOTATION values are equal iff they have the same expanded name
+/// (namespace URI + local name), exactly like xs:QName equality.
+/// F&O sec. 9.1: op:NOTATION-equal($value1 as xs:NOTATION, $value2 as xs:NOTATION) as xs:boolean
+/// Oracle: XPath F&O 3.2 section 9.1; NOTATION comparison is by expanded name.
+/// [SONNET-4.6] (sq-rcpdz)
+pub fn notation_equal<let NS1: u32, let LOCAL1: u32, let NS2: u32, let LOCAL2: u32>(
+    a: XsdQName<NS1, LOCAL1>,
+    b: XsdQName<NS2, LOCAL2>,
+) -> bool {
+    qname_equal(a, b)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/xpath/src/string.nr
+++ b/xpath/src/string.nr
@@ -72,22 +72,37 @@ pub fn string_length<let N: u32>(s: str<N>) -> u64 {
 /// fn:starts-with - Returns true if a string starts with a given prefix
 /// XPath: fn:starts-with($arg1 as xs:string?, $arg2 as xs:string?) as xs:boolean
 /// SPARQL: STRSTARTS(?str, ?prefix)
+///
+/// Matches on the LOGICAL content of the prefix (bytes before the first NUL),
+/// not the buffer capacity, so a prefix stored in a wider NUL-padded buffer
+/// compares only its meaningful bytes against the haystack. Per F&O sec.7.5.1:
+/// fn:starts-with($arg1, "") is true for any $arg1 (empty prefix always
+/// matches). [SONNET-4.6] sq-0ylr9
 pub fn starts_with<let N: u32, let M: u32>(s: str<N>, prefix: str<M>) -> bool {
-    if M > N {
-        false
-    } else {
-        let s_bytes = s.as_bytes();
-        let prefix_bytes = prefix.as_bytes();
-        let mut matches = true;
+    let s_bytes = s.as_bytes();
+    let prefix_bytes = prefix.as_bytes();
+    let s_len = logical_len_bytes(s_bytes);
+    let prefix_len = logical_len_bytes(prefix_bytes);
 
-        for i in 0..M {
-            if s_bytes[i] != prefix_bytes[i] {
-                matches = false;
-            }
+    // F&O sec.7.5.1: fn:starts-with($arg1, "") = true for any $arg1.
+    // A logically-empty prefix always matches; a prefix whose logical length
+    // exceeds the logical haystack never matches.
+    let fits = prefix_len <= s_len;
+    let mut matches = fits;
+
+    // Compare only the logical bytes of the prefix; NUL padding in the
+    // prefix buffer must not require NULs in the haystack.
+    for i in 0..M {
+        let in_range = ((i as u32) < prefix_len) & fits;
+        // Clamp for the (always-executed, post-flatten) static read; when
+        // in_range is true, i < prefix_len <= s_len <= N, so safe_s_idx == i.
+        let safe_s_idx = if i < N { i } else { 0 };
+        if in_range & (s_bytes[safe_s_idx] != prefix_bytes[i]) {
+            matches = false;
         }
-
-        matches
     }
+
+    matches
 }
 
 /// fn:ends-with - Returns true if a string ends with a given suffix
@@ -129,36 +144,59 @@ pub fn ends_with<let N: u32, let M: u32>(s: str<N>, suffix: str<M>) -> bool {
     matches
 }
 
-/// Helper function to find index of substring
+/// Helper function to find the byte-index of the first occurrence of
+/// `substring` within `s`, operating on LOGICAL lengths (bytes before the
+/// first NUL) for both arguments.
 ///
-/// **Performance Note**: This function has O(N*M) time complexity and, due to Noir's
-/// lack of early return/break, continues checking all positions even after finding a
-/// match. For large strings, this could significantly impact proof generation time.
+/// Returns the 0-based start index of the first match, or -1 if not found.
+/// Returns 0 for an empty needle (F&O sec.7.5.3: contains(X, "") = true).
+///
+/// **Performance Note**: O(N*M) time; due to Noir's lack of early-exit the
+/// scan continues past the first match. For large strings this increases
+/// proof-generation cost. [SONNET-4.6] sq-0ylr9
 fn index_of<let N: u32, let M: u32>(s: str<N>, substring: str<M>) -> i64 {
+    let s_bytes = s.as_bytes();
+    let sub_bytes = substring.as_bytes();
+    let s_len = logical_len_bytes(s_bytes);
+    let sub_len = logical_len_bytes(sub_bytes);
+
     let mut result: i64 = -1;
 
-    // Handle edge cases without early return
-    let size_ok = M <= N;
-    let empty_substring = M == 0;
+    // F&O sec.7.5.3: fn:contains($arg1, "") = true; by convention index_of
+    // returns 0 for an empty needle (found at position 0 of any string).
+    let empty_needle = sub_len == 0;
 
-    if empty_substring {
+    if empty_needle {
         result = 0;
-    } else if size_ok {
-        let s_bytes = s.as_bytes();
-        let sub_bytes = substring.as_bytes();
+    } else if sub_len <= s_len {
         let mut found_index: i64 = -1;
 
-        // Can't use break, so we iterate through all positions
-        for i in 0..(N - M + 1) {
-            let mut matches = true;
-            for j in 0..M {
-                if s_bytes[i + j] != sub_bytes[j] {
-                    matches = false;
+        // Iterate all possible start positions within the logical haystack.
+        // Comptime loop bound is N (buffer capacity); the runtime guard
+        // `(i as u32) + sub_len <= s_len` restricts to valid positions.
+        // Can't use break, so the scan continues past the first match.
+        for i in 0..N {
+            let start_valid = ((i as u32) + sub_len) <= s_len;
+            if start_valid {
+                let mut matches = true;
+                for j in 0..M {
+                    // Compare only the logical bytes of the needle; NUL
+                    // padding in the needle buffer must not require NULs in
+                    // the haystack.
+                    if (j as u32) < sub_len {
+                        let s_idx = i + j;
+                        // Clamp for the (always-executed, post-flatten) read;
+                        // within start_valid & j < sub_len, s_idx < s_len <=
+                        // N, so the clamp fires only on inert dead paths.
+                        let safe_s_idx = if s_idx < N { s_idx } else { 0 };
+                        if s_bytes[safe_s_idx] != sub_bytes[j] {
+                            matches = false;
+                        }
+                    }
                 }
-            }
-            // Only update if this is the first match
-            if matches & (found_index == -1) {
-                found_index = i as i64;
+                if matches & (found_index == -1) {
+                    found_index = i as i64;
+                }
             }
         }
         result = found_index;
@@ -653,7 +691,11 @@ pub fn substring_after<let N: u32, let M: u32>(s: str<N>, substr: str<M>) -> ([u
         // Substring not found, return empty
         (result, 0)
     } else {
-        let start_idx = (idx as u32) + (M as u32);
+        // Use the LOGICAL length of the needle (bytes before the first NUL),
+        // not the buffer capacity M.  With NUL-padded needles M > sub_len, so
+        // using M caused over-skipping (sq-0ylr9). [SONNET-4.6]
+        let sub_len = logical_len_bytes(substr.as_bytes());
+        let start_idx = (idx as u32) + sub_len;
         let mut result_len: u32 = 0;
 
         for i in 0..N {
@@ -1247,6 +1289,62 @@ fn test_substring_after() {
     }
 }
 
+// ============================================================================
+// [SONNET-4.6] sq-0ylr9: substring_after / substring_before with NUL-padded
+// needles: regression tests added after fixing the M-vs-sub_len over-skip bug.
+// Expected values from Python:
+//   >>> import re
+//   >>> def substring_after(s, needle): i=s.find(needle); return s[i+len(needle):] if i>=0 else ""
+//   >>> def substring_before(s, needle): i=s.find(needle); return s[:i] if i>=0 else ""
+// ============================================================================
+
+#[test]
+fn test_substring_after_padded_needle() {
+    // Python oracle: substring_after("abcdefgh", "cd") -> "efgh"
+    // "cd" stored in str<4> as "cd\0\0"; M=4 but logical needle length=2.
+    // Pre-fix this returned "gh" (over-skipped by 2 bytes). (sq-0ylr9)
+    let s: str<8> = "abcdefgh";
+    let needle: str<4> = "cd\0\0";
+    let (out, len) = substring_after::<8, 4>(s, needle);
+    assert(len == 4);
+    let expected = "efgh".as_bytes();
+    for i in 0..4 {
+        assert(out[i] == expected[i]);
+    }
+}
+
+#[test]
+fn test_substring_after_empty_needle_in_wider_buf() {
+    // F&O 7.5.5: fn:substring-after($arg1, "") = $arg1 for any $arg1.
+    // Python oracle: substring_after("hello", "") -> "hello"
+    // Logically-empty needle in a wider buffer (str<3> = "\0\0\0") must not
+    // drop M bytes; the whole string must be returned.
+    let s: str<5> = "hello";
+    let needle: str<3> = "\0\0\0";
+    let (out, len) = substring_after::<5, 3>(s, needle);
+    assert(len == 5);
+    let expected = "hello".as_bytes();
+    for i in 0..5 {
+        assert(out[i] == expected[i]);
+    }
+}
+
+#[test]
+fn test_substring_before_padded_needle() {
+    // Python oracle: substring_before("abcdefgh", "cd") -> "ab"
+    // "cd" stored in str<4> as "cd\0\0"; logical needle length=2.
+    // Locks the behavior: substring_before already used index_of which now
+    // computes the match position logically, so the result must stay "ab".
+    let s: str<8> = "abcdefgh";
+    let needle: str<4> = "cd\0\0";
+    let (out, len) = substring_before::<8, 4>(s, needle);
+    assert(len == 2);
+    let expected = "ab".as_bytes();
+    for i in 0..2 {
+        assert(out[i] == expected[i]);
+    }
+}
+
 #[test]
 fn test_upper_case() {
     let s: str<5> = "aBc12";
@@ -1378,4 +1476,140 @@ fn test_codepoint_equal() {
     let c: str<3> = "abd";
     assert(codepoint_equal::<3, 3>(a, b));
     assert(!codepoint_equal::<3, 3>(a, c));
+}
+
+// ============================================================================
+// [SONNET-4.6] sq-0ylr9: logical-length (NUL-padded NEEDLE) handling for
+// starts_with, contains, and the private index_of helper.
+// Bug class: a needle stored in a wider NUL-padded buffer compared all M
+// buffer bytes (including NULs) against the haystack, yielding false negatives.
+// Fix: derive needle logical length with logical_len_bytes; compare only the
+// meaningful bytes; empty needle = true per F&O sec.7.5.1/sec.7.5.3.
+// Expected values from an independent Python oracle over the F&O definitions.
+// ============================================================================
+
+// --- starts_with: NUL-padded prefix ---
+
+#[test]
+fn test_starts_with_padded_prefix_at_start() {
+    // Python oracle: "hello".startswith("he") == True
+    // prefix "he" stored in str<6>; NUL padding must not require NULs in s.
+    let s: str<5> = "hello";
+    let prefix: str<6> = "he\0\0\0\0";
+    assert(starts_with::<5, 6>(s, prefix));
+}
+
+#[test]
+fn test_starts_with_padded_prefix_full_content() {
+    // Python oracle: "hello".startswith("hello") == True
+    // prefix logical length == haystack logical length; both stored at exact
+    // and widened capacities.
+    let s: str<5> = "hello";
+    let prefix: str<8> = "hello\0\0\0";
+    assert(starts_with::<5, 8>(s, prefix));
+}
+
+#[test]
+fn test_starts_with_empty_needle() {
+    // F&O sec.7.5.1: fn:starts-with($arg1, "") = true for any $arg1.
+    // Python oracle: "hello".startswith("") == True
+    let s: str<5> = "hello";
+    let prefix: str<0> = "";
+    assert(starts_with::<5, 0>(s, prefix));
+}
+
+#[test]
+fn test_starts_with_padded_prefix_empty_needle_in_wider_buf() {
+    // A logically-empty prefix in a non-zero-capacity buffer also matches.
+    // Python oracle: "hello".startswith("") == True (NUL prefix = empty)
+    let s: str<5> = "hello";
+    let prefix: str<4> = "\0\0\0\0";
+    assert(starts_with::<5, 4>(s, prefix));
+}
+
+#[test]
+fn test_starts_with_padded_prefix_needle_longer_than_haystack() {
+    // Python oracle: "hi".startswith("hello") == False
+    // Logical needle (5) > logical haystack (2): never matches.
+    let s: str<2> = "hi";
+    let prefix: str<6> = "hello\0";
+    assert(!starts_with::<2, 6>(s, prefix));
+}
+
+#[test]
+fn test_starts_with_padded_prefix_mismatch() {
+    // Python oracle: "hello".startswith("world") == False
+    let s: str<5> = "hello";
+    let prefix: str<6> = "world\0";
+    assert(!starts_with::<5, 6>(s, prefix));
+}
+
+// --- contains / index_of: NUL-padded needle ---
+
+#[test]
+fn test_contains_padded_needle_at_end() {
+    // Python oracle: "llo" in "hello" == True
+    // needle "llo" stored in str<6>; NUL padding must not require NULs in s.
+    let s: str<5> = "hello";
+    let needle: str<6> = "llo\0\0\0";
+    assert(contains::<5, 6>(s, needle));
+}
+
+#[test]
+fn test_contains_padded_needle_in_middle() {
+    // Python oracle: "ell" in "hello" == True
+    let s: str<5> = "hello";
+    let needle: str<5> = "ell\0\0";
+    assert(contains::<5, 5>(s, needle));
+}
+
+#[test]
+fn test_contains_padded_needle_at_start() {
+    // Python oracle: "hel" in "hello" == True
+    let s: str<5> = "hello";
+    let needle: str<5> = "hel\0\0";
+    assert(contains::<5, 5>(s, needle));
+}
+
+#[test]
+fn test_contains_padded_needle_full_content() {
+    // Python oracle: "hello" in "hello" == True
+    // needle logical length == haystack logical length in a wider buffer.
+    let s: str<5> = "hello";
+    let needle: str<7> = "hello\0\0";
+    assert(contains::<5, 7>(s, needle));
+}
+
+#[test]
+fn test_contains_empty_needle() {
+    // F&O sec.7.5.3: fn:contains($arg1, "") = true for any $arg1.
+    // Python oracle: "" in "hello" == True (Python / XPath agree here)
+    let s: str<5> = "hello";
+    let needle: str<0> = "";
+    assert(contains::<5, 0>(s, needle));
+}
+
+#[test]
+fn test_contains_empty_needle_in_wider_buf() {
+    // Logically-empty needle in a non-zero-capacity buffer also matches.
+    let s: str<5> = "hello";
+    let needle: str<3> = "\0\0\0";
+    assert(contains::<5, 3>(s, needle));
+}
+
+#[test]
+fn test_contains_padded_needle_longer_than_haystack() {
+    // Python oracle: "hello" in "hi" == False
+    // Logical needle (5) > logical haystack (2): never matches.
+    let s: str<2> = "hi";
+    let needle: str<6> = "hello\0";
+    assert(!contains::<2, 6>(s, needle));
+}
+
+#[test]
+fn test_contains_padded_needle_no_match() {
+    // Python oracle: "xyz" in "hello" == False
+    let s: str<5> = "hello";
+    let needle: str<5> = "xyz\0\0";
+    assert(!contains::<5, 5>(s, needle));
 }

--- a/xpath/src/xpath_fn.nr
+++ b/xpath/src/xpath_fn.nr
@@ -281,11 +281,14 @@ pub use crate::time::adjust_time_to_timezone as adjust_time_to_timezone;
 pub use crate::numeric::round_half_to_even_int as round_half_to_even;
 
 // ============================================================================
-// YearMonthDuration Component Extraction
+// Duration Component Extraction (sq-u91ki) [SONNET-4.6]
+// Generic dispatch on the duration subtype via the YearMonthComponents trait:
+// xs:dayTimeDuration -> 0 (F&O sec. 8.4.3 / sec. 8.4.4),
+// xs:yearMonthDuration -> real component values.
 // ============================================================================
 
-// fn:years-from-duration (for yearMonthDuration)
-pub use crate::year_month_duration::years_from_duration as years_from_duration;
+// fn:years-from-duration (dayTimeDuration -> 0, yearMonthDuration -> real years)
+pub use crate::duration::years_from_duration as years_from_duration;
 
-// fn:months-from-duration (for yearMonthDuration)
-pub use crate::year_month_duration::months_from_duration as months_from_duration;
+// fn:months-from-duration (dayTimeDuration -> 0, yearMonthDuration -> real months)
+pub use crate::duration::months_from_duration as months_from_duration;

--- a/xpath/src/xpath_op.nr
+++ b/xpath/src/xpath_op.nr
@@ -404,3 +404,6 @@ pub use crate::sequence::range_to as to;
 
 // op:QName-equal
 pub use crate::qname::qname_equal as QName_equal;
+
+// op:NOTATION-equal (F&O sec. 9.1: equality by expanded name, same as QName)
+pub use crate::qname::notation_equal as NOTATION_equal;


### PR DESCRIPTION
> 🤖 SPARQ agent — sync of the noir_XPath published face after sparq PRs #1541, #1547, #1550. Third batched re-sync; bead sq-tlu1z.

## Drift ported

**xpath/src/string.nr** (sparq #1541)
- `starts_with`, `index_of` helper (used by `contains`, `substring_before`, `substring_after`): compare only logical bytes (bytes before first NUL), not buffer capacity; fixes false negatives with NUL-padded needles
- `substring_after`: skip exactly `sub_len` (logical length) bytes instead of buffer capacity `M`, fixing the over-skip bug
- 14 new oracle-quoted unit tests

**xpath/src/duration.nr** (sparq #1547)
- `YearMonthComponents` trait + `impl` for both `XsdDayTimeDuration` (returns 0, F&O sec. 8.4.3/8.4.4) and `XsdYearMonthDuration` (real component)
- Generic `years_from_duration<T>` / `months_from_duration<T>` dispatching on either subtype
- 5 new in-file tests (positive, negative, zero dayTimeDuration)

**xpath/src/lib.nr** + **xpath/src/xpath_fn.nr** (sparq #1547/#1550)
- Re-export `years_from_duration`/`months_from_duration`/`YearMonthComponents` from `duration` (generic dispatch, covers both subtypes)
- Export `notation_equal` from `qname`

**xpath/src/qname.nr** + **xpath/src/xpath_op.nr** (sparq #1550)
- `notation_equal` (F&O sec. 9.1: equality by expanded name, same as `qname_equal`)
- `NOTATION_equal` re-export in `xpath_op`

**test_packages** (sparq #1550, 7 packages)
- Real test vectors for: `fn:contains`, `fn:ends-with`, `fn:starts-with`, `fn:string-length`, `op:add-dayTimeDuration-to-dateTime`, `op:NOTATION-equal`, `op:subtract-dayTimeDuration-from-dateTime`
- KNOWN_FAILING list is now empty for these functions

## Verification
- `nargo test --workspace` — all tests pass (pinned 1.0.0-beta.21)
- Recursive diff against sparq source confirms byte-identical content for the 13 ported files
- Standalone-specific files (ci.yml, README, Nargo.toml, vendor/, scripts/) unchanged

## Related
- sparq PR #1541: fix(zk/xpath): logical-length NUL-padded needle for starts_with/contains/index_of
- sparq PR #1547: feat(zk/xpath): DayTimeDuration overloads for years/months-from-duration
- sparq PR #1550: test(zk/xpath): real test vectors for 7 placeholder packages + op:NOTATION-equal impl
- Prior sync: sparq-org/noir_XPath PR #43 (sq-zqtd3)
- Missing producer for copilot-review-posted status context: sq-umj0p