### PR TITLE
chore: empty KNOWN_FAILING — all 9 packages now pass after #1550/#1559 re-syncs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -47,14 +47,16 @@ set with no workflow edit.
 
 ### KNOWN_FAILING
 
-A short list of REAL packages with a documented, tracked latent failure. They are
-**skipped with a `::warning`, never masked silently**:
+A list (in `scripts/run_real_tests.sh`) of REAL packages with a documented,
+tracked latent failure. Entries are **skipped with a `::warning`, never masked
+silently**.
 
-| Package | Reason |
+The list is **currently empty**. Historical entries, all retired:
+
+| Former entry | Resolution |
 |---|---|
-| `xpath_test_fnmonths_from_duration` | generated test applies the fn to an `XsdDayTimeDuration`, but the library exposes it only for `XsdYearMonthDuration` (XPath says return 0); needs a DayTimeDuration overload |
-| `xpath_test_fnyears_from_duration` | same as above |
-| `xpath_test_fncontains`, `xpath_test_fnends_with`, `xpath_test_fnstarts_with`, `xpath_test_fnstring_length`, `xpath_test_opadd_daytimeduration_to_datetime`, `xpath_test_opnotation_equal`, `xpath_test_opsubtract_daytimeduration_from_datetime` | single `assert(false)` placeholder — no qt3tests case was convertible. (These also match the stub filter, so they are excluded before the KNOWN_FAILING check is reached.) |
+| `xpath_test_fncontains`, `xpath_test_fnends_with`, `xpath_test_fnstarts_with`, `xpath_test_fnstring_length`, `xpath_test_opadd_daytimeduration_to_datetime`, `xpath_test_opnotation_equal`, `xpath_test_opsubtract_daytimeduration_from_datetime` | were single `assert(false)` placeholders; received real qt3tests vectors in sparq PR #1550 (synced in face re-sync #3/#4) and now pass |
+| `xpath_test_fnmonths_from_duration`, `xpath_test_fnyears_from_duration` | now compile and pass — the fn applied to an `xs:dayTimeDuration` returns 0 per XPath F&O |
 
 ## Running the tests
 
@@ -76,14 +78,11 @@ nargo test --package xpath_unit_tests
 
 ### Latest measured results (nargo 1.0.0-beta.21)
 
-- `xpath` library: **128 `#[test]` functions** pass.
+- `xpath` library: **162 `#[test]` functions** pass.
 - `xpath_unit_tests`: **292 `#[test]` functions** pass.
-- `test_packages` partition: **103 REAL | 257 stub-wired (excluded)**.
-- REAL packages run: **101 passed**, **2 skipped** (KNOWN_FAILING:
-  `fnmonths_from_duration`, `fnyears_from_duration`), **0 unexpected failures**.
-
-(The remaining 7 KNOWN_FAILING entries are `assert(false)` placeholders already
-excluded by the stub filter, so they never reach the KNOWN_FAILING check.)
+- `test_packages` partition: **110 REAL | 250 stub-wired (excluded)**.
+- REAL packages run: **110 passed**, **0 skipped** (KNOWN_FAILING is empty),
+  **0 unexpected failures** — **1403 tests** across the real packages.
 
 ## Upstream → current test mapping (preservation certificate)
 

--- a/scripts/run_real_tests.sh
+++ b/scripts/run_real_tests.sh
@@ -27,23 +27,16 @@ shopt -s nullglob
 cd "$(dirname "$0")/.."
 
 # --- KNOWN_FAILING (bare package names under test_packages/) ---
-# Placeholder packages (no qt3tests case convertible -- also stub-excluded above,
-# listed here for completeness) plus the two real packages whose generated tests
-# do not compile against the current library API:
-#   fnmonths_from_duration / fnyears_from_duration -- generated tests pass an
-#   XsdDayTimeDuration but the library exposes these fns only for
-#   XsdYearMonthDuration (XPath says return 0); needs DayTimeDuration overloads.
-KNOWN_FAILING=(
-  "xpath_test_fncontains"
-  "xpath_test_fnends_with"
-  "xpath_test_fnstarts_with"
-  "xpath_test_fnstring_length"
-  "xpath_test_opadd_daytimeduration_to_datetime"
-  "xpath_test_opnotation_equal"
-  "xpath_test_opsubtract_daytimeduration_from_datetime"
-  "xpath_test_fnmonths_from_duration"
-  "xpath_test_fnyears_from_duration"
-)
+# Currently EMPTY: every previously-listed package now passes.
+#   - The 7 former assert(false) placeholders (fncontains, fnends_with,
+#     fnstarts_with, fnstring_length, opadd_daytimeduration_to_datetime,
+#     opnotation_equal, opsubtract_daytimeduration_from_datetime) received
+#     real qt3tests vectors in sparq PR #1550 (synced in face re-sync #3/#4).
+#   - fnmonths_from_duration / fnyears_from_duration now compile and pass
+#     (fn applied to an xs:dayTimeDuration returns 0 per XPath F&O).
+# If a real package regresses, add its bare name here with a reason and a
+# tracking reference; it is skipped with a ::warning, never masked silently.
+KNOWN_FAILING=()
 
 fail_fast="${FAIL_FAST:-0}"   # FAIL_FAST=1 to stop on first failure
 


### PR DESCRIPTION
## Summary

Follow-up to #45 (face re-sync #4, bead sq-ev2hm). The `KNOWN_FAILING` skip list in `scripts/run_real_tests.sh` still listed 9 packages, but **all 9 now pass** on main — verified individually with nargo 1.0.0-beta.21:

| Package | Status | Why it passes now |
|---|---|---|
| `xpath_test_fncontains` (11), `fnends_with` (10), `fnstarts_with` (10), `fnstring_length` (9), `opadd_daytimeduration_to_datetime` (7), `opnotation_equal` (6), `opsubtract_daytimeduration_from_datetime` (7) | PASS | received real qt3tests vectors in sparq PR #1550 (synced in re-syncs #3/#4); no longer `assert(false)` placeholders, no longer stub-classified |
| `xpath_test_fnmonths_from_duration` (1), `fnyears_from_duration` (1) | PASS | now compile and pass — fn applied to an `xs:dayTimeDuration` returns 0 per XPath F&O |

With the list still populated, CI **silently skipped** 9 now-real, now-passing packages. This PR:

- empties `KNOWN_FAILING=()` in `scripts/run_real_tests.sh` (with a comment documenting the retirements and how to re-add entries)
- updates `TESTING.md`: retires the KNOWN_FAILING table (kept as resolution history) and refreshes the measured results

## Test plan

- [x] Full `scripts/run_real_tests.sh` on this branch (nargo 1.0.0-beta.21), exit 0:
  - `xpath` library: 162 tests passed
  - `xpath_unit_tests`: 292 tests passed
  - partition: **110 REAL | 250 stub-wired (excluded)** (was 103/257)
  - REAL packages: **110 passed, 0 skipped, 0 unexpected failures** — 1403 tests
- [x] `bash -n` syntax check on the edited script (empty-array expansion is safe on the runner's bash 5.x under `set -u`)

> 🤖 **SPARQ agent** — follow-up to face re-sync #4 (bead sq-ev2hm). The bead called for checking/emptying the standalone repo's KNOWN_FAILING list; it turned out to be the array in `scripts/run_real_tests.sh`, not a file. All 9 listed packages verified passing individually before un-skipping; full real suite green with 0 skips. (Producer of `copilot-review-posted` still missing — tracked in sparq bead sq-umj0p.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)